### PR TITLE
P0+高优修复: 跨namespace串记忆 / 幂等hash / fail-open / persona缺失 / 文档漂移

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ https://<你的 Worker 地址>/mcp?token=<MEMORY_MCP_API_KEY>
 | `ANTHROPIC_THINKING_BUDGET` | `1024` | 思考 token 预算（1024-32000） |
 | `ANTHROPIC_CACHE_ENABLED` | `true` | Claude prompt cache 开关 |
 | `ANTHROPIC_CACHE_TTL` | `5m` | cache 时长（5m 或 1h） |
-| `ANTHROPIC_AUTO_CACHE_ENABLED` | `false` | Anthropic 顶层 automatic cache |
+| `ANTHROPIC_AUTO_CACHE_ENABLED` | `true` | Anthropic 顶层 automatic cache |
 | `ANTHROPIC_ROLLING_CACHE_ENABLED` | `true` | 滚动 cache 打点 |
 | `ANTHROPIC_ROLLING_CACHE_WINDOW_SIZE` | `20` | 前端历史窗口大小 |
 | `FORCE_ANTHROPIC_NATIVE` | 空 | 设 `true` 强制走 Anthropic native |
@@ -234,7 +234,7 @@ https://<你的 Worker 地址>/mcp?token=<MEMORY_MCP_API_KEY>
 | `DREAM_MAX_RUNS` | `10` | 每次定时任务最多连续 dream 批数 |
 | `DREAM_MAX_TOKENS` | `8000` | dream 模型最多输出 token |
 | `DREAM_MEMORY_CONTEXT_LIMIT` | `40` | dream 时参考的旧记忆数量 |
-| `DREAM_EXCPTT_LIMIT` | `8` | dream 每天最多保存的重要原文段落 |
+| `DREAM_EXCERPT_LIMIT` | `8` | dream 每天最多保存的重要原文段落 |
 | `EMPTY_MEMORY_MIN_CHARS` | `4` | 清理短空记忆的阈值 |
 | `PUBLIC_MODEL_NAME` | `companion` | 客户端看到的模型名 |
 | `IM_API_KEY` | 空 | 第二把钥匙（IM bot 用） |

--- a/src/api/chatCompletions.ts
+++ b/src/api/chatCompletions.ts
@@ -4,7 +4,7 @@ import { getOrCreateConversation } from "../db/conversations";
 import { listMemories } from "../db/memories";
 import { saveAssistantMessage, saveUserMessages } from "../db/messages";
 import { saveUsageLog } from "../db/usageLogs";
-import { extractLastUserText, injectMemoryPatchAsSystemMessage, selectMemoriesForInjection } from "../memory/inject";
+import { extractLastUserText, formatMemoryPatch, injectMemoryPatchAsSystemMessage, selectMemoriesForInjection } from "../memory/inject";
 import { toMemoryApiRecord } from "../memory/search";
 import { assemble } from "../assembler/assemble";
 import { PERSONA_MEMORY_TYPES } from "../assembler/types";
@@ -22,7 +22,7 @@ import { streamAnthropicToOpenAI } from "../proxy/streamAnthropic";
 import { streamOpenAIWithTee } from "../proxy/streamOpenAI";
 import { CONTENT_RULES } from "../preset/regexRules";
 import { applyRegexRules } from "../preset/regexPipeline";
-import type { Env, MemoryApiRecord, OpenAIChatRequest, OpenAIChatResponse } from "../types";
+import type { Env, MemoryApiRecord, OpenAIChatMessage, OpenAIChatRequest, OpenAIChatResponse } from "../types";
 import { openAiError } from "../utils/json";
 import { hasImageContent } from "../utils/messages";
 
@@ -39,6 +39,25 @@ export function hasToolContent(body: OpenAIChatRequest): boolean {
   return body.messages.some(
     (m) => m.role === "tool" || (m.role === "assistant" && m.tool_calls != null)
   );
+}
+
+// Tool-path fallback (assembler not used here yet): inject pinned persona as a
+// leading system message, then the RAG memory patch after the existing system
+// messages. If persona is empty this degrades to injectMemoryPatchAsSystemMessage.
+function injectPersonaAndMemoryPatches(
+  request: OpenAIChatRequest,
+  pinnedPersonaMemories: MemoryApiRecord[],
+  memories: MemoryApiRecord[]
+): OpenAIChatRequest {
+  const personaPatch = formatMemoryPatch(pinnedPersonaMemories);
+  if (!personaPatch) return injectMemoryPatchAsSystemMessage(request, memories);
+
+  const personaMessage: OpenAIChatMessage = { role: "system", content: personaPatch };
+  const withPersona: OpenAIChatRequest = {
+    ...request,
+    messages: [personaMessage, ...request.messages]
+  };
+  return injectMemoryPatchAsSystemMessage(withPersona, memories);
 }
 
 /**
@@ -127,7 +146,7 @@ export async function handleChatCompletions(
   try {
     if (provider === "anthropic") {
       if (hasToolContent(body)) {
-        // Tool messages / tool_calls not yet supported by assembler — fall back
+        // Tool path uses legacy adapter (buildAnthropicNativeRequest) which includes stable memory pack; assembler integration is tracked separately.
         const anthropicRequest = await buildAnthropicNativeRequest(body, {
           env,
           targetModel,
@@ -151,8 +170,9 @@ export async function handleChatCompletions(
       }
     } else {
       if (hasToolContent(body)) {
-        // Tool messages / tool_calls not yet supported by assembler — fall back
-        const patchedBody = injectMemoryPatchAsSystemMessage(body, memories);
+        // Tool path: assembler not wired here yet; inject persona + RAG patches
+        // directly so pinned persona is not lost on the OpenAI tool fallback.
+        const patchedBody = injectPersonaAndMemoryPatches(body, pinnedPersonaMemories, memories);
         const upstreamRequest = buildOpenAICompatRequest(patchedBody, targetModel);
         upstream = await callOpenAICompat(env, upstreamRequest);
       } else {

--- a/src/assembler/assemble.ts
+++ b/src/assembler/assemble.ts
@@ -2,8 +2,8 @@
  * assemble — main entry point for the v4 Prompt Assembler.
  *
  * Converts an OpenAIChatRequest into an AssembledPrompt.
- * Adapters (anthropic/openai) will consume the output in P1.3.
- * This module is NOT wired into the adapters yet.
+ * The adapters (anthropic/openai) consume the output via the
+ * buildAnthropicRequestFromAssembled / buildOpenAIRequestFromAssembled helpers.
  *
  * Determinism: given the same request + pre-fetched data, the output is
  * bit-for-bit identical across calls. No timestamps, no request ids.

--- a/src/assembler/blocks.ts
+++ b/src/assembler/blocks.ts
@@ -8,8 +8,7 @@
  * AssembledPrompt.messages with original content preserved, NOT to system_blocks.
  *
  * This module is self-contained; it does NOT import from memory/inject.ts
- * or the adapters. The adapters will be rewired to consume AssembledPrompt
- * in a later phase (P1.3).
+ * or the adapters.
  */
 
 import type { MemoryApiRecord, OpenAIChatMessage } from "../types";

--- a/src/assembler/toAnthropic.ts
+++ b/src/assembler/toAnthropic.ts
@@ -2,8 +2,7 @@
  * Pure conversion: AssembledPrompt → Anthropic wire format types.
  *
  * These helpers do NOT call any adapter, DB, or external service.
- * The existing anthropicAdapter.ts is untouched; adapters will import
- * these functions in P1.3 integration (a later step).
+ * The anthropicAdapter consumes them via buildAnthropicRequestFromAssembled.
  *
  * Determinism: given the same AssembledPrompt, output is bit-for-bit identical.
  */

--- a/src/assembler/toOpenAI.ts
+++ b/src/assembler/toOpenAI.ts
@@ -2,8 +2,7 @@
  * Pure conversion: AssembledPrompt → OpenAI wire format types.
  *
  * These helpers do NOT call any adapter, DB, or external service.
- * The existing openaiAdapter.ts is untouched; adapters will import
- * these functions in P1.3 integration (a later step).
+ * The openaiAdapter consumes them via buildOpenAIRequestFromAssembled.
  *
  * Determinism: given the same AssembledPrompt, output is bit-for-bit identical.
  */

--- a/src/db/messages.ts
+++ b/src/db/messages.ts
@@ -9,6 +9,13 @@ function contentToText(content: OpenAIChatMessage["content"]): string {
   return JSON.stringify(content);
 }
 
+// Stable-hash normalization: trim + collapse whitespace so retrying the same
+// (conversationId, role, content) yields an identical hash. The DB id stays
+// random; only the hash drops it — that is what makes the hash idempotent.
+function normalizeContent(content: string): string {
+  return content.replace(/\s+/g, " ").trim();
+}
+
 export async function saveUserMessages(
   db: D1Database,
   input: {
@@ -29,7 +36,7 @@ export async function saveUserMessages(
   for (const message of userMessages) {
     const content = contentToText(message.content);
     const id = newId("msg");
-    const hash = await sha256Hex(`${input.conversationId}:${id}:${message.role}:${content}`);
+    const hash = await sha256Hex(`${input.conversationId}:${message.role}:${normalizeContent(content)}`);
     ids.push(id);
 
     await db

--- a/src/memory/filter.ts
+++ b/src/memory/filter.ts
@@ -23,6 +23,7 @@ export interface MemoryFilterMeta {
   reranker_model?: string;
   reranker_count?: number;
   reranker_reason?: string;
+  fallback_used?: boolean;
 }
 
 const COMPRESSION_RESPONSE_SCHEMA = {
@@ -510,6 +511,21 @@ export async function filterAndCompressMemories(
   return result.data;
 }
 
+// Fail-open path for error branches (gated by MEMORY_FILTER_FAIL_OPEN==="true"):
+// return un-compressed reranker top results instead of []. Keeps status="error"
+// + original reason so operators see fail-open fired; sets fallback_used=true.
+function buildFailOpenResult(
+  reranked: { data: MemoryApiRecord[]; status: "disabled" | "success" | "error"; model: string; reason?: string },
+  maxOutput: number,
+  errorMeta: MemoryFilterMeta
+): { data: MemoryApiRecord[]; meta: MemoryFilterMeta } {
+  const fallbackData = reranked.data.slice(0, maxOutput);
+  return {
+    data: fallbackData,
+    meta: { ...errorMeta, output_count: fallbackData.length, fallback_used: true }
+  };
+}
+
 export async function filterAndCompressMemoriesWithMeta(
   env: Env,
   input: { query: string; memories: MemoryApiRecord[] }
@@ -569,6 +585,7 @@ export async function filterAndCompressMemoriesWithMeta(
     maxOutputChars: getMaxOutputChars(env)
   });
   const maxTokens = getMaxTokens(env);
+  const failOpen = env.MEMORY_FILTER_FAIL_OPEN === "true";
 
   try {
     const output =
@@ -576,52 +593,49 @@ export async function filterAndCompressMemoriesWithMeta(
         ? await callOpenAICompatFilter(env, prompt, model, maxTokens)
         : await callWorkersAiFilter(env, prompt, getWorkersAiModel(env) || model, maxTokens);
     if (!output) {
-      return {
-        data: [],
-        meta: {
-          ...activeMeta,
-          status: "error",
-          reason: "empty_model_output",
-          output_shape: describeModelOutput(output),
-          reranker_status: reranked.status,
-          reranker_model: reranked.model,
-          reranker_count: reranked.data.length,
-          ...(reranked.reason ? { reranker_reason: reranked.reason } : {})
-        }
+      const errorMeta: MemoryFilterMeta = {
+        ...activeMeta,
+        status: "error",
+        reason: "empty_model_output",
+        output_shape: describeModelOutput(output),
+        reranker_status: reranked.status,
+        reranker_model: reranked.model,
+        reranker_count: reranked.data.length,
+        ...(reranked.reason ? { reranker_reason: reranked.reason } : {})
       };
+      if (failOpen) return buildFailOpenResult(reranked, maxOutput, errorMeta);
+      return { data: [], meta: errorMeta };
     }
 
     const items = parseCompressedItems(output);
     if (!items) {
-      return {
-        data: [],
-        meta: {
-          ...activeMeta,
-          status: "error",
-          reason: "invalid_model_output",
-          output_shape: describeModelOutput(output),
-          reranker_status: reranked.status,
-          reranker_model: reranked.model,
-          reranker_count: reranked.data.length,
-          ...(reranked.reason ? { reranker_reason: reranked.reason } : {})
-        }
+      const errorMeta: MemoryFilterMeta = {
+        ...activeMeta,
+        status: "error",
+        reason: "invalid_model_output",
+        output_shape: describeModelOutput(output),
+        reranker_status: reranked.status,
+        reranker_model: reranked.model,
+        reranker_count: reranked.data.length,
+        ...(reranked.reason ? { reranker_reason: reranked.reason } : {})
       };
+      if (failOpen) return buildFailOpenResult(reranked, maxOutput, errorMeta);
+      return { data: [], meta: errorMeta };
     }
 
     if (items.length !== reranked.data.length) {
-      return {
-        data: [],
-        meta: {
-          ...activeMeta,
-          status: "error",
-          reason: "slot_count_mismatch",
-          output_shape: describeModelOutput(output),
-          reranker_status: reranked.status,
-          reranker_model: reranked.model,
-          reranker_count: reranked.data.length,
-          ...(reranked.reason ? { reranker_reason: reranked.reason } : {})
-        }
+      const errorMeta: MemoryFilterMeta = {
+        ...activeMeta,
+        status: "error",
+        reason: "slot_count_mismatch",
+        output_shape: describeModelOutput(output),
+        reranker_status: reranked.status,
+        reranker_model: reranked.model,
+        reranker_count: reranked.data.length,
+        ...(reranked.reason ? { reranker_reason: reranked.reason } : {})
       };
+      if (failOpen) return buildFailOpenResult(reranked, maxOutput, errorMeta);
+      return { data: [], meta: errorMeta };
     }
 
     const filtered = mergeCompressedItems(reranked.data, items).slice(0, maxOutput);
@@ -640,17 +654,16 @@ export async function filterAndCompressMemoriesWithMeta(
     };
   } catch (error) {
     console.error("memory filter failed", error);
-    return {
-      data: [],
-      meta: {
-        ...activeMeta,
-        status: "error",
-        reason: error instanceof Error && error.message ? error.message : "model_error",
-        reranker_status: reranked.status,
-        reranker_model: reranked.model,
-        reranker_count: reranked.data.length,
-        ...(reranked.reason ? { reranker_reason: reranked.reason } : {})
-      }
+    const errorMeta: MemoryFilterMeta = {
+      ...activeMeta,
+      status: "error",
+      reason: error instanceof Error && error.message ? error.message : "model_error",
+      reranker_status: reranked.status,
+      reranker_model: reranked.model,
+      reranker_count: reranked.data.length,
+      ...(reranked.reason ? { reranker_reason: reranked.reason } : {})
     };
+    if (failOpen) return buildFailOpenResult(reranked, maxOutput, errorMeta);
+    return { data: [], meta: errorMeta };
   }
 }

--- a/src/memory/search.ts
+++ b/src/memory/search.ts
@@ -186,8 +186,10 @@ async function searchWithVectorize(
   if (!vector) return null;
 
   let result = await queryVectorize(env, vector, input, true);
+  let usedUnfilteredFallback = false;
   if (result.matches.length === 0) {
     result = await queryVectorize(env, vector, input, false);
+    usedUnfilteredFallback = true;
   }
 
   const minScore = getMinScore(env);
@@ -196,6 +198,19 @@ async function searchWithVectorize(
 
   for (const match of result.matches) {
     if (match.score < minScore) continue;
+
+    // Unfiltered fallback can return vectors from any namespace. Force a
+    // strict metadata filter here so foreign-namespace memories never leak in
+    // via toLegacyMemoryRecord's input.namespace fallback. Vectors without an
+    // explicit namespace field are dropped — we do NOT fall back to
+    // input.namespace (that is the bug this guard prevents).
+    if (usedUnfilteredFallback) {
+      const md = (match.metadata || {}) as Record<string, unknown>;
+      if (typeof md.namespace !== "string" || md.namespace !== input.namespace) continue;
+      const status = md.status;
+      if (status !== undefined && status !== "active") continue;
+    }
+
     const id = getRefId(match);
     if (id) scoredIds.set(id, match.score);
     const legacy = toLegacyMemoryRecord(match, input);

--- a/src/memory/vectorStore.ts
+++ b/src/memory/vectorStore.ts
@@ -406,6 +406,12 @@ export async function searchVectorMemories(
   return [...matchesByVectorId.values()]
     .flatMap((match): MemoryApiRecord[] => {
       if (match.score < getMinScore(env)) return [];
+      // Legacy (unfiltered) query branch is only for migration-era vectors
+      // that may lack a namespace. Require an explicit metadata namespace
+      // matching input.namespace; do not let vectorMetadataToMemoryRecord's
+      // "default" fallback pass through, or a named "default" namespace leaks.
+      const md = (match.metadata || {}) as Record<string, unknown>;
+      if (typeof md.namespace !== "string" || md.namespace !== input.namespace) return [];
       const record = vectorMetadataToMemoryRecord(match, match.score);
       if (!record || record.namespace !== input.namespace) return [];
       if (input.types && input.types.length > 0 && !input.types.includes(record.type)) return [];

--- a/src/types.ts
+++ b/src/types.ts
@@ -51,6 +51,7 @@ export interface Env {
   MEMORY_FILTER_OUTPUT_CHARS?: string;
   MEMORY_FILTER_MAX_TOKENS?: string;
   MEMORY_FILTER_MIN_SCORE?: string;
+  MEMORY_FILTER_FAIL_OPEN?: string;
   MEMORY_EXTRACT_EVERY_N_MESSAGES?: string;
   MEMORY_MIN_IMPORTANCE?: string;
   INJECTION_MODE?: string;


### PR DESCRIPTION
## 背景
GPT Pro 静态审查了 9 点问题。Codex 的 PR #3 只碰了第 5 点缓存的一小块,其余 P0/高优都没动。本 PR 修复第一批(第 1+2 波,6 处代码 + 1 处文档),共 7 个原子 commit。

> 注:审查报告第 2 点(filter.ts sanitizer 把中文洗成渣)经复核 **不成立** —— `[^|。\\n]` 只匹配 `<time_reminder>` 标签内部,正常中文不受影响。本 PR 不改 sanitizer。

## 改动清单(commit 逐一可 revert)

### P0(第 1 波)
1. **`7b14d31` fix(search): 强制过滤 Vectorize 无过滤 fallback 的跨 namespace 记忆**
   - d1 backend:`queryVectorize(useFilter=false)` 分支的 matches 要求 `metadata.namespace === input.namespace && status active`,缺 namespace 字段直接丢弃(不再用 `input.namespace` 兜底)
2. **`d2dd99b` fix(vectorStore): 收紧 legacy 查询的 namespace 泄漏**
   - 生产 MEMORY_BACKEND=vectorize 走这条:`searchVectorMemories` flatMap 里要求 metadata 显式带 namespace 且匹配,堵住 `vectorMetadataToMemoryRecord` 的 `"default"` 兜底泄漏
3. **`b8b47c7` fix(messages): hash 改用稳定字段**
   - `sha256Hex(conversationId:role:normalizedContent)`,去掉随机 `id`。同句重试 hash 不变,为幂等去重铺路(未加 UNIQUE 约束)

### 高优(第 2 波)
4. **`70b2c31` fix(filter): 加 `MEMORY_FILTER_FAIL_OPEN` 开关**
   - 4 个 error 分支(空模型输出/解析失败/slot 数不匹配/catch)在 `MEMORY_FILTER_FAIL_OPEN=true` 时退回 reranker top 结果,meta 加 `fallback_used:true`;默认 fail-closed 保持不变
5. **`e06f311` fix(chatCompletions): OpenAI tool fallback 补 pinned persona**
   - 新增 `injectPersonaAndMemoryPatches`:persona system message 放最前,再插 RAG patch。Anthropic tool 路径已有 `buildStableMemoryPack`,不动;只补 OpenAI 这条
6. **`7d93a84` docs(assembler): 清理 4 个文件头过时注释**
   - assemble/blocks/toOpenAI/toAnthropic 的 "P1.3 / not-yet-wired" 已与现状不符(adapters 早已集成 AssembledPrompt),更新为反映现状
7. **`47c69dd` docs(readme): 修 DREAM_EXCERPT_LIMIT typo + 对齐 ANTHROPIC_AUTO_CACHE_ENABLED**
   - README:237 `DREAM_EXCPTT_LIMIT` → `DREAM_EXCERPT_LIMIT`(和 types.ts/setup script/dailyDigest.ts 对齐)
   - README:212 `ANTHROPIC_AUTO_CACHE_ENABLED` 默认值 `false` → `true`(和 wrangler.toml:49 对齐)

## 验证
- \`npm run typecheck\` → exit 0
- \`npm run verify\` → 175 passed, 0 failed
- 无 \`as any\` / \`@ts-ignore\` / \`@ts-expect-error\`
- 每个改动单独 commit,可独立 revert

## 未做(留第 3 波)
- 图片链路改两步导盲犬
- tool fallback 真正接 assembler(本次只补 persona)
- 缓存可视化 debug endpoint + 单元测试
- PR #3(anthropicAdapter multi-anchor cache)待这一波稳定后顺手 merge

## 风险
- 改动 1/2 改了 namespace 过滤语义:迁移期遗留的缺 namespace 字段的向量将 **不再被召回**。这是有意为之(宁可漏召回也不串线)。如果生产有这类向量且确实属于当前 namespace,需先通过管理端给它们补上 metadata.namespace 再合并。
- 改动 3 hash 公式变了:存量记录的 hash 不变(只影响新写入),但同句重发从此产生相同 hash —— 如需启用幂等去重可后续加 UNIQUE 约束。

## 审查 & 决策
**不要直接 merge。** 请逐个 commit 看 diff。特别是改动 1/2 的 namespace 过滤逻辑,建议你对照生产里 Vectorize metadata 的实际 schema 确认不会误杀合法向量。