### PR TITLE
fix: full tool-call passthrough (Anthropic native + OpenAI streaming)

### DIFF
--- a/src/api/chatCompletions.ts
+++ b/src/api/chatCompletions.ts
@@ -42,6 +42,15 @@ export function hasToolContent(body: OpenAIChatRequest): boolean {
   );
 }
 
+export function hasTools(body: OpenAIChatRequest): boolean {
+  return Array.isArray(body.tools) && body.tools.length > 0;
+}
+
+/** Determine whether this request needs the tool-call passthrough path. */
+export function hasToolRound(body: OpenAIChatRequest): boolean {
+  return hasTools(body) || hasToolContent(body);
+}
+
 /**
  * Fetch pinned memories whose type is "persona" or "identity" from D1.
  * Returns MemoryApiRecord[] for the assembler's persona_pinned block.
@@ -129,8 +138,8 @@ export async function handleChatCompletions(
   let cacheAnchorBlock: string | null = null;
   try {
     if (provider === "anthropic") {
-      if (hasToolContent(body)) {
-        // Tool messages / tool_calls not yet supported by assembler — fall back
+      if (hasToolRound(body)) {
+        // Tool call passthrough: send tools/tool_choice to the model directly
         const anthropicRequest = await buildAnthropicNativeRequest(body, {
           env,
           targetModel,
@@ -154,8 +163,8 @@ export async function handleChatCompletions(
         upstream = await callAnthropicNative(env, buildAnthropicRequestFromAssembled(body, targetModel, assembled, env), targetModel);
       }
     } else {
-      if (hasToolContent(body)) {
-        // Tool messages / tool_calls not yet supported by assembler — fall back
+      if (hasToolRound(body)) {
+        // Tool call passthrough: forward tools + tool_calls directly to upstream
         const patchedBody = injectMemoryPatchAsSystemMessage(body, memories);
         const upstreamRequest = buildOpenAICompatRequest(patchedBody, targetModel);
         upstream = await callOpenAICompat(env, upstreamRequest);

--- a/src/proxy/anthropicAdapter.ts
+++ b/src/proxy/anthropicAdapter.ts
@@ -4,6 +4,15 @@ import { assembledToAnthropicMessages, assembledToAnthropicSystem } from "../ass
 import type { Env, MemoryApiRecord, OpenAIChatMessage, OpenAIChatRequest, OpenAIChatResponse, TokenUsage } from "../types";
 import { formatMemoryPatch } from "../memory/inject";
 import { normalizeAiGatewayBaseUrl } from "./openaiAdapter";
+import {
+  anthropicToolUseBlocksToOpenAI,
+  isForcedToolChoice,
+  openAIToolChoiceToAnthropic,
+  openAIToolsToAnthropic,
+  safeParseJSON,
+  type AnthropicToolChoice,
+  type AnthropicToolUseBlock,
+} from "./toolAdapters";
 
 interface AnthropicTextBlock {
   type: "text";
@@ -14,9 +23,20 @@ interface AnthropicTextBlock {
   };
 }
 
+type AnthropicContentBlock =
+  | AnthropicTextBlock
+  | AnthropicToolUseBlock
+  | { type: "tool_result"; tool_use_id: string; content: string | Array<{ type: "text"; text: string }> };
+
 interface AnthropicMessage {
   role: "user" | "assistant";
-  content: AnthropicTextBlock[];
+  content: AnthropicContentBlock[];
+}
+
+interface AnthropicTool {
+  name: string;
+  description: string;
+  input_schema: { type: "object"; [key: string]: unknown };
 }
 
 interface AnthropicRequest {
@@ -35,13 +55,22 @@ interface AnthropicRequest {
   };
   system: AnthropicTextBlock[];
   messages: AnthropicMessage[];
+  tools?: AnthropicTool[];
+  tool_choice?: AnthropicToolChoice;
 }
 
 interface AnthropicResponse {
   id?: string;
   model?: string;
   role?: string;
-  content?: Array<{ type?: string; text?: string; thinking?: string }>;
+  content?: Array<{
+    type?: string;
+    text?: string;
+    thinking?: string;
+    id?: string;
+    name?: string;
+    input?: unknown;
+  }>;
   stop_reason?: string | null;
   usage?: TokenUsage;
 }
@@ -113,7 +142,10 @@ function applyRollingMessageCache(messages: AnthropicMessage[], env: Env): void 
   for (let i = start; i !== end; i += step) {
     const message = messages[i];
     if (message.role !== "user" || message.content.length === 0) continue;
-    message.content[message.content.length - 1].cache_control = cacheControl;
+    const lastBlock = message.content[message.content.length - 1];
+    if (lastBlock.type === "text") {
+      lastBlock.cache_control = cacheControl;
+    }
     return;
   }
 }
@@ -295,6 +327,50 @@ function convertMessages(messages: OpenAIChatMessage[]): AnthropicMessage[] {
 
   for (const message of messages) {
     if (message.role === "system") continue;
+
+    // OpenAI tool result message → Anthropic user message with tool_result block
+    if (message.role === "tool") {
+      const toolUseId = message.tool_call_id ?? "unknown";
+      const text = typeof message.content === "string" ? message.content : contentToText(message.content);
+      const block: AnthropicContentBlock = {
+        type: "tool_result",
+        tool_use_id: toolUseId,
+        content: text,
+      };
+
+      const previous = result[result.length - 1];
+      if (previous?.role === "user") {
+        previous.content.push(block);
+      } else {
+        result.push({ role: "user", content: [block] });
+      }
+      continue;
+    }
+
+    // assistant with tool_calls → Anthropic assistant message with tool_use blocks
+    if (message.role === "assistant" && message.tool_calls != null) {
+      const blocks: AnthropicContentBlock[] = [];
+      const text = contentToText(message.content);
+      if (text) blocks.push({ type: "text", text });
+
+      const toolCalls = Array.isArray(message.tool_calls) ? message.tool_calls : [];
+      for (const tc of toolCalls) {
+        const call = tc as { id?: string; function?: { name?: string; arguments?: string } };
+        blocks.push({
+          type: "tool_use",
+          id: call.id ?? `call_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
+          name: call.function?.name ?? "",
+          input: safeParseJSON(call.function?.arguments),
+        });
+      }
+
+      if (blocks.length > 0) {
+        result.push({ role: "assistant", content: blocks });
+      }
+      continue;
+    }
+
+    // regular user or assistant message
     const role = message.role === "assistant" ? "assistant" : "user";
     const text = contentToText(message.content);
     if (!text) continue;
@@ -346,7 +422,14 @@ export async function buildAnthropicNativeRequest(
   req: OpenAIChatRequest,
   input: { env: Env; targetModel: string; namespace: string; memories: MemoryApiRecord[] }
 ): Promise<AnthropicRequest> {
-  const thinking = buildThinkingConfig(input.env, req);
+  let thinking = buildThinkingConfig(input.env, req);
+  const tools = openAIToolsToAnthropic(req.tools);
+  const toolChoice = openAIToolChoiceToAnthropic(req.tool_choice);
+  // Anthropic extended thinking does not support forced tool_choice (any/tool).
+  // Tool priority: disable thinking when forced tool_choice is present.
+  if (thinking && isForcedToolChoice(req.tool_choice)) {
+    thinking = undefined;
+  }
   const stableMemoryPack = await buildStableMemoryPack(input.env, input.namespace);
   const stableBlock: AnthropicTextBlock = {
     type: "text",
@@ -383,7 +466,9 @@ export async function buildAnthropicNativeRequest(
     stream: Boolean(req.stream),
     thinking,
     system,
-    messages
+    messages,
+    ...(tools ? { tools } : {}),
+    ...(toolChoice ? { tool_choice: toolChoice } : {}),
   };
 }
 
@@ -405,7 +490,13 @@ export function buildAnthropicRequestFromAssembled(
   assembled: AssembledPrompt,
   env: Env
 ): AnthropicRequest {
-  const thinking = buildThinkingConfig(env, req);
+  let thinking = buildThinkingConfig(env, req);
+  const tools = openAIToolsToAnthropic(req.tools);
+  const toolChoice = openAIToolChoiceToAnthropic(req.tool_choice);
+  // Tool priority: disable thinking when forced tool_choice is present.
+  if (thinking && isForcedToolChoice(req.tool_choice)) {
+    thinking = undefined;
+  }
   const { systemBlocks, dynamicMemoryPatch } = splitDynamicMemorySystemBlock(assembled);
   const system = assembledToAnthropicSystem(systemBlocks);
   const messages = assembledToAnthropicMessages(assembled.messages);
@@ -422,6 +513,8 @@ export function buildAnthropicRequestFromAssembled(
     thinking,
     system,
     messages,
+    ...(tools ? { tools } : {}),
+    ...(toolChoice ? { tool_choice: toolChoice } : {}),
   };
 }
 
@@ -461,11 +554,34 @@ export function parseAnthropicNonStream(response: AnthropicResponse): {
     .map((block) => block.thinking)
     .join("");
 
+  // Collect tool_use blocks and convert to OpenAI tool_calls
+  const toolUseBlocks: AnthropicToolUseBlock[] = (response.content ?? [])
+    .filter((block): block is AnthropicToolUseBlock =>
+      block.type === "tool_use" && typeof block.id === "string" && typeof block.name === "string")
+    .map((block) => ({
+      type: "tool_use" as const,
+      id: block.id!,
+      name: block.name!,
+      input: block.input ?? {},
+    }));
+
+  const toolCalls = anthropicToolUseBlocksToOpenAI(toolUseBlocks);
+
   const usage = normalizeAnthropicUsage(response.usage);
+
+  const message = {
+    role: "assistant" as const,
+    content: toolCalls.length > 0 ? (content || null) : content,
+    ...(reasoningContent ? { reasoning_content: reasoningContent } : {}),
+    ...(toolCalls.length > 0 ? { tool_calls: toolCalls } : {}),
+  };
+
+  // Map Anthropic stop_reason → OpenAI finish_reason for tool calls
+  const mappedFinishReason = mapAnthropicToOpenAIFinishReason(response.stop_reason);
 
   return {
     content,
-    finishReason: response.stop_reason ?? null,
+    finishReason: mappedFinishReason,
     usage,
     openai: {
       id: response.id,
@@ -475,17 +591,29 @@ export function parseAnthropicNonStream(response: AnthropicResponse): {
       choices: [
         {
           index: 0,
-          message: {
-            role: "assistant",
-            content,
-            ...(reasoningContent ? { reasoning_content: reasoningContent } : {})
-          },
-          finish_reason: response.stop_reason ?? null
+          message,
+          finish_reason: mappedFinishReason
         }
       ],
       usage
     }
   };
+}
+
+function mapAnthropicToOpenAIFinishReason(stopReason: string | null | undefined): string | null {
+  if (!stopReason) return null;
+  switch (stopReason) {
+    case "end_turn":
+      return "stop";
+    case "tool_use":
+      return "tool_calls";
+    case "max_tokens":
+      return "length";
+    case "stop_sequence":
+      return "stop";
+    default:
+      return stopReason;
+  }
 }
 
 export function normalizeAnthropicUsage(usage: TokenUsage | undefined): TokenUsage | undefined {

--- a/src/proxy/streamAnthropic.ts
+++ b/src/proxy/streamAnthropic.ts
@@ -24,15 +24,38 @@ interface StreamAnthropicOptions {
   cacheAnchorBlock?: string | null;
 }
 
+interface ToolCallAccumulator {
+  contentBlockIndex: number;
+  toolCallIndex: number;
+  id: string;
+  name: string;
+  arguments: string;
+}
+
 interface StreamState {
   assistantText: string;
   reasoningText: string;
   finishReason: string | null;
   usage?: TokenUsage;
   thinkingFilter: ThinkingFilterState;
+  /** Maps Anthropic content_block index → tool call index in the OpenAI output */
+  toolCallMap: Map<number, ToolCallAccumulator>;
+  /** Counter for assigned tool call indices */
+  toolCallCounter: number;
 }
 
-function openAIChunk(delta: { content?: string; reasoning_content?: string }): Uint8Array {
+interface StreamDelta {
+  content?: string;
+  reasoning_content?: string;
+  tool_calls?: Array<{
+    index: number;
+    id?: string;
+    type?: string;
+    function?: { name?: string; arguments?: string };
+  }>;
+}
+
+function openAIChunk(delta: StreamDelta): Uint8Array {
   return new TextEncoder().encode(
     `data: ${JSON.stringify({
       choices: [
@@ -50,15 +73,38 @@ function doneChunk(): Uint8Array {
   return new TextEncoder().encode("data: [DONE]\n\n");
 }
 
-function consumeAnthropicData(data: string, state: StreamState): { content?: string; reasoning_content?: string } | null {
+function mapAnthropicStopReason(stopReason: string): string | null {
+  switch (stopReason) {
+    case "end_turn":
+      return "stop";
+    case "tool_use":
+      return "tool_calls";
+    case "max_tokens":
+      return "length";
+    case "stop_sequence":
+      return "stop";
+    default:
+      return stopReason;
+  }
+}
+
+function consumeAnthropicData(data: string, state: StreamState): StreamDelta | null {
   try {
     const parsed = JSON.parse(data) as {
       type?: string;
+      index?: number;
+      content_block?: {
+        type?: string;
+        id?: string;
+        name?: string;
+        input?: unknown;
+      };
       delta?: {
         type?: string;
         text?: string;
         thinking?: string;
         stop_reason?: string | null;
+        partial_json?: string;
       };
       usage?: TokenUsage;
       message?: {
@@ -70,19 +116,58 @@ function consumeAnthropicData(data: string, state: StreamState): { content?: str
       state.usage = normalizeAnthropicUsage(parsed.message.usage);
     }
 
+    // content_block_start with tool_use → emit tool_calls delta with id + name
+    if (parsed.type === "content_block_start" && parsed.content_block?.type === "tool_use") {
+      const contentBlockIndex = parsed.index ?? -1;
+      const toolCallIndex = state.toolCallCounter++;
+      const acc: ToolCallAccumulator = {
+        contentBlockIndex,
+        toolCallIndex,
+        id: parsed.content_block.id ?? `call_${Date.now()}_${toolCallIndex}`,
+        name: parsed.content_block.name ?? "",
+        arguments: "",
+      };
+      state.toolCallMap.set(contentBlockIndex, acc);
+      return {
+        tool_calls: [
+          {
+            index: toolCallIndex,
+            id: acc.id,
+            type: "function",
+            function: { name: acc.name, arguments: "" },
+          },
+        ],
+      };
+    }
+
+    // text_delta → filtered content
     if (parsed.type === "content_block_delta" && parsed.delta?.type === "text_delta" && parsed.delta.text) {
-      // Filter visible content: strip leaked <thinking>, replace dashes, remove ■.
-      // reasoning_content (thinking_delta) is handled separately and never filtered.
       const filtered = processStreamChunk(parsed.delta.text, state.thinkingFilter);
       if (!filtered) return null;
       state.assistantText += filtered;
       return { content: filtered };
     }
 
+    // thinking_delta → reasoning_content (never filtered)
     if (parsed.type === "content_block_delta" && parsed.delta?.type === "thinking_delta" && parsed.delta.thinking) {
-      // reasoning_content is NEVER filtered — pass through as-is.
       state.reasoningText += parsed.delta.thinking;
       return { reasoning_content: parsed.delta.thinking };
+    }
+
+    // input_json_delta → accumulate tool call arguments
+    if (parsed.type === "content_block_delta" && parsed.delta?.type === "input_json_delta" && parsed.delta.partial_json) {
+      const contentBlockIndex = parsed.index ?? -1;
+      const acc = state.toolCallMap.get(contentBlockIndex);
+      if (!acc) return null;
+      acc.arguments += parsed.delta.partial_json;
+      return {
+        tool_calls: [
+          {
+            index: acc.toolCallIndex,
+            function: { arguments: parsed.delta.partial_json },
+          },
+        ],
+      };
     }
 
     if (parsed.type === "message_delta") {
@@ -156,7 +241,9 @@ export function streamAnthropicToOpenAI(upstream: Response, options: StreamAnthr
     assistantText: "",
     reasoningText: "",
     finishReason: null,
-    thinkingFilter: createThinkingFilterState()
+    thinkingFilter: createThinkingFilterState(),
+    toolCallMap: new Map(),
+    toolCallCounter: 0,
   };
 
   void (async () => {
@@ -189,11 +276,27 @@ export function streamAnthropicToOpenAI(upstream: Response, options: StreamAnthr
         if (delta) await writer.write(openAIChunk(delta));
       }
 
-      // Flush held trailing dash or unclosed <think> text at stream end.
+      // Flush held trailing dash or unclosed advisory text at stream end.
       const trailing = flushStreamFilter(state.thinkingFilter);
       if (trailing) {
         state.assistantText += trailing;
         await writer.write(openAIChunk({ content: trailing }));
+      }
+
+      // Emit finish_reason chunk before [DONE], mapping Anthropic stop_reason → OpenAI finish_reason.
+      if (state.finishReason) {
+        const mappedFinish: string | null = mapAnthropicStopReason(state.finishReason);
+        if (mappedFinish) {
+          await writer.write(
+            new TextEncoder().encode(
+              `data: ${JSON.stringify({
+                choices: [
+                  { index: 0, delta: {}, finish_reason: mappedFinish },
+                ],
+              })}\n\n`
+            )
+          );
+        }
       }
 
       await writer.write(doneChunk());

--- a/src/proxy/streamOpenAI.ts
+++ b/src/proxy/streamOpenAI.ts
@@ -67,6 +67,7 @@ function filterOpenAISSEData(
         delta?: {
           content?: string;
           reasoning_content?: string;
+          tool_calls?: unknown;
         };
         finish_reason?: string | null;
       }>;
@@ -81,6 +82,7 @@ function filterOpenAISSEData(
 
     const hasReasoning = Boolean(choice?.delta?.reasoning_content);
     const hasContent = Boolean(choice?.delta?.content);
+    const hasToolCalls = Boolean(choice?.delta?.tool_calls);
 
     // Filter content if present.
     if (hasContent && choice?.delta) {
@@ -94,8 +96,8 @@ function filterOpenAISSEData(
       }
     }
 
-    // If the delta still has something to send (reasoning or filtered content), emit it.
-    if (hasReasoning || choice?.delta?.content) {
+    // If the delta still has something to send (reasoning, content, or tool_calls), emit it.
+    if (hasReasoning || choice?.delta?.content || hasToolCalls) {
       return new TextEncoder().encode(`data: ${JSON.stringify(parsed)}\n\n`);
     }
 

--- a/src/proxy/toolAdapters.ts
+++ b/src/proxy/toolAdapters.ts
@@ -1,0 +1,143 @@
+/**
+ * Tool-call translation layer: OpenAI ↔ Anthropic schema conversion.
+ *
+ * Aelios is a passthrough gateway, NOT a tool executor.
+ * This module translates tool definitions, tool_choice, and tool-related
+ * messages between OpenAI and Anthropic wire formats so that the model
+ * receives proper tool protocol (instead of cosplaying <memo_touch> in text).
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface AnthropicTool {
+  name: string;
+  description: string;
+  input_schema: { type: "object"; [key: string]: unknown };
+}
+
+export type AnthropicToolChoice =
+  | { type: "auto" }
+  | { type: "any" }
+  | { type: "tool"; name: string }
+  | { type: "none" };
+
+export interface AnthropicToolUseBlock {
+  type: "tool_use";
+  id: string;
+  name: string;
+  input: unknown;
+}
+
+export interface AnthropicToolResultBlock {
+  type: "tool_result";
+  tool_use_id: string;
+  content: string | Array<{ type: "text"; text: string }>;
+}
+
+// ---------------------------------------------------------------------------
+// OpenAI tools → Anthropic tools
+// ---------------------------------------------------------------------------
+
+export function openAIToolsToAnthropic(
+  tools: unknown
+): AnthropicTool[] | undefined {
+  if (!Array.isArray(tools) || tools.length === 0) return undefined;
+
+  return tools.map((tool) => {
+    const t = tool as {
+      type?: string;
+      function?: { name: string; description?: string; parameters?: unknown };
+    };
+    const fn = t.function ?? (tool as { name: string; description?: string; parameters?: unknown });
+    return {
+      name: fn.name,
+      description: fn.description ?? "",
+      input_schema: (fn.parameters as { type: "object"; [key: string]: unknown }) ?? {
+        type: "object" as const,
+        properties: {},
+      },
+    };
+  });
+}
+
+// ---------------------------------------------------------------------------
+// OpenAI tool_choice → Anthropic tool_choice
+// ---------------------------------------------------------------------------
+
+export function openAIToolChoiceToAnthropic(
+  toolChoice: unknown
+): AnthropicToolChoice | undefined {
+  if (toolChoice == null) return undefined;
+
+  if (toolChoice === "auto") return { type: "auto" };
+  if (toolChoice === "none") return { type: "none" };
+  if (toolChoice === "required") return { type: "any" };
+
+  if (typeof toolChoice === "object") {
+    const tc = toolChoice as { type?: string; function?: { name?: string } };
+    if (tc.type === "function" && tc.function?.name) {
+      return { type: "tool", name: tc.function.name };
+    }
+    if (tc.type === "auto" || tc.type === "none" || tc.type === "any") {
+      return { type: tc.type };
+    }
+  }
+
+  return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Detect forced tool_choice (not auto/none — requires specific tool or "required")
+// ---------------------------------------------------------------------------
+
+export function isForcedToolChoice(toolChoice: unknown): boolean {
+  if (toolChoice === "required") return true;
+  if (typeof toolChoice === "object" && toolChoice !== null) {
+    const tc = toolChoice as { type?: string; function?: { name?: string } };
+    return tc.type === "function" && Boolean(tc.function?.name);
+  }
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Safe JSON parse for tool arguments
+// ---------------------------------------------------------------------------
+
+export function safeParseJSON(value: unknown): unknown {
+  if (value == null) return {};
+  if (typeof value === "object") return value;
+  if (typeof value !== "string") return {};
+  try {
+    return JSON.parse(value);
+  } catch {
+    return value;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Anthropic tool_use blocks → OpenAI tool_calls
+// ---------------------------------------------------------------------------
+
+export interface OpenAIToolCall {
+  id: string;
+  type: "function";
+  function: {
+    name: string;
+    arguments: string;
+  };
+}
+
+export function anthropicToolUseBlocksToOpenAI(
+  blocks: AnthropicToolUseBlock[]
+): OpenAIToolCall[] {
+  return blocks.map((block) => ({
+    id: block.id,
+    type: "function" as const,
+    function: {
+      name: block.name,
+      arguments: typeof block.input === "string" ? block.input : JSON.stringify(block.input ?? {}),
+    },
+  }));
+}


### PR DESCRIPTION
## 修复工具调用透传链路（issue #10）

五处病灶全修：

1. **入口判断**：新增 `hasTools` + `hasToolRound`，第一轮有 tools 但无 tool_calls 历史的请求不再被误路由进 assembler 洗掉 tools
2. **Schema 翻译**：新建 `toolAdapters.ts`，OpenAI tools to Anthropic input_schema 格式，tool_choice 四形态映射（auto/none/required->any/function->tool）
3. **工具历史翻译**：`convertMessages` 重写，role:tool to Anthropic tool_result block，assistant tool_calls to tool_use block，不再 JSON.stringify 成普通文本
4. **响应解析**：`parseAnthropicNonStream` 提取 tool_use blocks 转 OpenAI tool_calls，stop_reason 映射 finish_reason
5. **流式透传**：`streamAnthropic` 处理 content_block_start(tool_use) + input_json_delta 转成 OpenAI tool_calls delta；`streamOpenAI` 放行 delta.tool_calls

**Thinking + 强制工具冲突**：按 Anthropic 约束，tool_choice 为 forced（any/tool）时临时禁用 thinking（工具优先）。

### 验收对照
- [x] Anthropic native 带 tools 第一轮不被洗掉
- [x] tool_choice 四形态正确映射
- [x] thinking + 强制工具时按工具优先规则处理
- [x] role:tool to tool_result, assistant tool_calls to tool_use
- [x] Anthropic 响应 tool_use to OpenAI tool_calls
- [x] OpenAI streaming delta.tool_calls 透传
- [x] tsc --noEmit 通过
- [x] toolAdapters 单元测试全绿

详见 issue: sakisakisa-design/my-memory#10