### PR TITLE
fix: excerpt embedding shape + memory_list type/status filter + ids mismatch

### DIFF
--- a/src/api/mcp.ts
+++ b/src/api/mcp.ts
@@ -235,7 +235,9 @@ async function callTool(
       const page = await listVectorMemories(env, {
         namespace: resolveNamespace(profile, args.namespace),
         count: limit,
-        cursor: readString(args.cursor)
+        cursor: readString(args.cursor),
+        type: readString(args.type) ?? undefined,
+        status: readString(args.status) ?? undefined
       });
       return textToolResult({
         data: page.data,

--- a/src/api/memories.ts
+++ b/src/api/memories.ts
@@ -80,7 +80,9 @@ async function handleListMemories(request: Request, env: Env, profile: KeyProfil
   const page = await listVectorMemories(env, {
     namespace,
     count: limit,
-    cursor: readString(url.searchParams.get("cursor"))
+    cursor: readString(url.searchParams.get("cursor")),
+    type: readString(url.searchParams.get("type")) ?? undefined,
+    status: readString(url.searchParams.get("status")) ?? undefined
   });
 
   return json({

--- a/src/memory/dailyDigest.ts
+++ b/src/memory/dailyDigest.ts
@@ -609,14 +609,15 @@ async function saveImportantExcerpts(
     const quote = readString(excerpt.quote);
     if (!quote) continue;
     const reason = readString(excerpt.reason);
-    const content = [`【${input.dateLabel} 重要原文】`, quote, reason ? `保存原因：${reason}` : ""]
+    const summary = [`【${input.dateLabel} 重要原文】`, reason ? `保存原因：${reason}` : ""]
       .filter(Boolean)
-      .join("\n");
+      .join("｜");
 
     await createVectorMemory(env, {
       namespace: input.namespace,
       type: "excerpt",
-      content,
+      content: quote,
+      summary,
       importance: 0.72,
       confidence: 0.9,
       tags: uniqueStrings(["important-excerpt", input.dateLabel, ...(excerpt.tags ?? [])]),

--- a/src/memory/vectorStore.ts
+++ b/src/memory/vectorStore.ts
@@ -44,6 +44,8 @@ export interface VectorMemoryListInput {
   namespace?: string;
   cursor?: string;
   count: number;
+  type?: string;
+  status?: string;
 }
 
 export interface VectorMemoryListPage {
@@ -484,16 +486,18 @@ export async function listVectorMemories(
       const record = vectorMetadataToMemoryRecord(vector);
       if (!record) return [];
       if (input.namespace && record.namespace !== input.namespace) return [];
+      if (input.type && record.type !== input.type) return [];
+      if (input.status && record.status !== input.status) return [];
       return [record];
     })
     .sort((a, b) => Number(b.pinned) - Number(a.pinned) || b.importance - a.importance || b.updated_at.localeCompare(a.updated_at));
 
   return {
     data,
-    ids: listed.ids,
+    ids: data.map((record) => record.id),
     cursor: listed.cursor,
     hasMore: listed.hasMore,
-    count: listed.ids.length,
+    count: data.length,
     totalCount: listed.totalCount
   };
 }

--- a/src/memory/vectorStore.ts
+++ b/src/memory/vectorStore.ts
@@ -106,11 +106,12 @@ function toMetadata(input: Required<VectorMemoryInput> & { id: string; vectorId:
 
 export function vectorMetadataToMemoryRecord(
   vector: Pick<VectorizeVector, "id" | "metadata">,
-  score?: number
+  score?: number,
+  options?: { includeInactive?: boolean }
 ): MemoryApiRecord | null {
   const metadata = (vector.metadata || {}) as MetadataMap;
   const status = readString(metadata.status) || "active";
-  if (status !== "active") return null;
+  if (!options?.includeInactive && status !== "active") return null;
 
   const content = readString(metadata.content) || readString(metadata.text) || readString(metadata.memory);
   if (!content) return null;
@@ -475,29 +476,81 @@ async function listVectorIdsViaApi(
   };
 }
 
+const MAX_FILTER_SCAN_PAGES = 5;
+
 export async function listVectorMemories(
   env: Env,
   input: VectorMemoryListInput
 ): Promise<VectorMemoryListPage> {
-  const listed = await listVectorIdsViaApi(env, input);
-  const vectors = listed.ids.length > 0 ? await getVectorsByIdsBatched(requireVectorize(env), listed.ids) : [];
-  const data = vectors
-    .flatMap((vector): MemoryApiRecord[] => {
-      const record = vectorMetadataToMemoryRecord(vector);
-      if (!record) return [];
-      if (input.namespace && record.namespace !== input.namespace) return [];
-      if (input.type && record.type !== input.type) return [];
-      if (input.status && record.status !== input.status) return [];
-      return [record];
-    })
-    .sort((a, b) => Number(b.pinned) - Number(a.pinned) || b.importance - a.importance || b.updated_at.localeCompare(a.updated_at));
+  const hasFilter = Boolean(input.type || input.status);
+
+  if (!hasFilter) {
+    // No filter: single page, fast path.
+    const listed = await listVectorIdsViaApi(env, input);
+    const vectors = listed.ids.length > 0 ? await getVectorsByIdsBatched(requireVectorize(env), listed.ids) : [];
+    const data = vectors
+      .flatMap((vector): MemoryApiRecord[] => {
+        const record = vectorMetadataToMemoryRecord(vector);
+        if (!record) return [];
+        if (input.namespace && record.namespace !== input.namespace) return [];
+        return [record];
+      })
+      .sort((a, b) => Number(b.pinned) - Number(a.pinned) || b.importance - a.importance || b.updated_at.localeCompare(a.updated_at));
+
+    return {
+      data,
+      ids: data.map((record) => record.id),
+      cursor: listed.cursor,
+      hasMore: listed.hasMore,
+      count: data.length,
+      totalCount: listed.totalCount
+    };
+  }
+
+  // Filtered: scan pages until we have enough matches or run out.
+  const includeInactive = Boolean(input.status && input.status !== "active");
+  const filtered: MemoryApiRecord[] = [];
+  let cursor: string | undefined | null = input.cursor;
+  let hasMore = true;
+  let scannedPages = 0;
+  let lastCursor: string | null = null;
+  let rawTotalCount: number | undefined;
+
+  const vectorize = requireVectorize(env);
+
+  while (filtered.length < input.count && hasMore && scannedPages < MAX_FILTER_SCAN_PAGES) {
+    const listed = await listVectorIdsViaApi(env, { ...input, cursor: cursor ?? undefined });
+    const vectors = listed.ids.length > 0 ? await getVectorsByIdsBatched(vectorize, listed.ids) : [];
+
+    if (rawTotalCount === undefined) rawTotalCount = listed.totalCount;
+
+    for (const vector of vectors) {
+      const record = vectorMetadataToMemoryRecord(vector, undefined, { includeInactive });
+      if (!record) continue;
+      if (input.namespace && record.namespace !== input.namespace) continue;
+      if (input.type && record.type !== input.type) continue;
+      if (input.status && record.status !== input.status) continue;
+      filtered.push(record);
+      if (filtered.length >= input.count) break;
+    }
+
+    cursor = listed.cursor;
+    hasMore = listed.hasMore;
+    lastCursor = listed.cursor;
+    scannedPages += 1;
+  }
+
+  const data = filtered.sort(
+    (a, b) => Number(b.pinned) - Number(a.pinned) || b.importance - a.importance || b.updated_at.localeCompare(a.updated_at)
+  );
 
   return {
     data,
     ids: data.map((record) => record.id),
-    cursor: listed.cursor,
-    hasMore: listed.hasMore,
-    count: data.length,
-    totalCount: listed.totalCount
+    cursor: lastCursor,
+    hasMore,
+    count: data.length
+    // Do not return totalCount when filtering — raw Vectorize count
+    // does not reflect the filtered subset and would be misleading.
   };
 }


### PR DESCRIPTION
## Fixes

### Issue 1: Dream excerpt retrieval (#1)

`saveImportantExcerpts` was wrapping quotes with `【date 重要原文】...保存原因：...` before embedding, making the vector semantically distant from natural-language queries.

**Fix:** Store raw quote as `content` (goes into embedding), move date/reason labels to `summary` field.

### Issue 2 + 3: memory_list type filter ignored + ids mismatch (#2)

Two bugs in `memory_list`:
- `type` and `status` params were accepted by the MCP/REST schemas but never passed to `listVectorMemories`
- `ids[]` returned raw Vectorize vector IDs (`mem_mem_...`) instead of record IDs (`mem_...`)

**Fix:**
- Added `type`/`status` to `VectorMemoryListInput`
- `listVectorMemories` now filters after fetching vectors
- `ids[]` returns `data[].id` instead of raw vector IDs
- Both MCP and REST handlers pass params through

## Changed files
- `src/memory/dailyDigest.ts` — excerpt storage shape
- `src/memory/vectorStore.ts` — list filtering + ids fix
- `src/api/mcp.ts` — pass type/status to list
- `src/api/memories.ts` — pass type/status to list