### PR TITLE
feat: improve Claude prompt cache stability for multi-client scenarios

### DIFF
--- a/src/assembler/blocks.ts
+++ b/src/assembler/blocks.ts
@@ -159,6 +159,10 @@ function extractSystemTexts(messages: OpenAIChatMessage[]): string[] {
 function isVolatileTimeLine(line: string): boolean {
   const trimmed = line.trim();
   if (!trimmed) return false;
+  // Multi-line time formats (e.g. Operit injects time as separate lines).
+  if (/^[【\[](?:当前|现在|系统|本地)?(?:时间|日期|日期时间|时间戳)[】\]]$/.test(trimmed)) return true;
+  if (/^\d{4}[-/]\d{1,2}[-/]\d{1,2}(\s+\d{1,2}:\d{2}(:\d{2})?)?$/.test(trimmed)) return true;
+  if (/^星期\s*[:：]/.test(trimmed)) return true;
   const normalized = trimmed.replace(/^[>*\-\d.)\s]+/, "").trim();
   const lower = normalized.toLowerCase();
 
@@ -179,6 +183,10 @@ function isVolatileTimeLine(line: string): boolean {
   return hasTimeLabel && (hasDateLikeValue || /\btimezone\b/i.test(normalized) || /时区/.test(normalized));
 }
 
+// Operit 等客户端注入的"动态段"标题白名单
+// 看到这些标题，整段（直到空行）都视为 volatile，避免破坏 Claude prompt cache
+const VOLATILE_SECTION_HEADER = /^[【\[](?:当前时间|相关记忆|动态上下文|当前位置|系统状态)[】\]]$/;
+
 function splitClientSystemTexts(texts: string[]): { stable: string[]; volatile: string[] } {
   const stable: string[] = [];
   const volatile: string[] = [];
@@ -186,10 +194,34 @@ function splitClientSystemTexts(texts: string[]): { stable: string[]; volatile: 
   for (const text of texts) {
     const stableLines: string[] = [];
     const volatileLines: string[] = [];
+    let inVolatileSection = false;
 
     for (const line of text.split(/\r?\n/)) {
-      if (isVolatileTimeLine(line)) volatileLines.push(line.trim());
-      else stableLines.push(line);
+      const trimmed = line.trim();
+
+      // 进入新的 volatile 段
+      if (VOLATILE_SECTION_HEADER.test(trimmed)) {
+        inVolatileSection = true;
+        volatileLines.push(trimmed);
+        continue;
+      }
+
+      // 已经在 volatile 段内
+      if (inVolatileSection) {
+        if (!trimmed) {
+          inVolatileSection = false;
+          continue;
+        }
+        volatileLines.push(trimmed);
+        continue;
+      }
+
+      // 段外按原逻辑逐行判断
+      if (isVolatileTimeLine(line)) {
+        volatileLines.push(line.trim());
+      } else {
+        stableLines.push(line);
+      }
     }
 
     const stableText = stableLines.join("\n").trim();

--- a/src/proxy/anthropicAdapter.ts
+++ b/src/proxy/anthropicAdapter.ts
@@ -129,24 +129,29 @@ export function getAnthropicCacheMode(env: Env): string | null {
   return parts.join("_");
 }
 
-function applyRollingMessageCache(messages: AnthropicMessage[], env: Env): void {
+function applyRollingMessageCache(messages: AnthropicMessage[], env: Env, systemCacheCount: number = 0): void {
   const cacheControl = buildCacheControl(env);
   if (!cacheControl) return;
   if (env.ANTHROPIC_ROLLING_CACHE_ENABLED === "false") return;
 
-  const isFullWindow = messages.length >= getRollingCacheWindowSize(env);
-  const start = isFullWindow ? 0 : messages.length - 1;
-  const end = isFullWindow ? messages.length : -1;
-  const step = isFullWindow ? 1 : -1;
+  // Anthropic limits cache_control markers to 4 total; subtract system-level markers.
+  const MAX_MESSAGE_MARKERS = Math.max(1, 4 - systemCacheCount);
 
-  for (let i = start; i !== end; i += step) {
-    const message = messages[i];
-    if (message.role !== "user" || message.content.length === 0) continue;
-    const lastBlock = message.content[message.content.length - 1];
-    if (lastBlock.type === "text") {
-      lastBlock.cache_control = cacheControl;
+  const userIndices: number[] = [];
+  for (let i = 0; i < messages.length; i++) {
+    if (messages[i].role === "user" && messages[i].content.length > 0) {
+      userIndices.push(i);
     }
-    return;
+  }
+  if (userIndices.length === 0) return;
+
+  const n = userIndices.length;
+  const markers = Math.min(n, MAX_MESSAGE_MARKERS);
+  const gap = Math.max(1, Math.floor(n / markers));
+
+  for (let m = 0; m < markers; m++) {
+    const idx = userIndices[m * gap];
+    messages[idx].content[messages[idx].content.length - 1].cache_control = cacheControl;
   }
 }
 
@@ -469,6 +474,7 @@ export async function buildAnthropicNativeRequest(
     messages,
     ...(tools ? { tools } : {}),
     ...(toolChoice ? { tool_choice: toolChoice } : {}),
+    metadata: { user_id: "operit-user" },
   };
 }
 
@@ -515,6 +521,7 @@ export function buildAnthropicRequestFromAssembled(
     messages,
     ...(tools ? { tools } : {}),
     ...(toolChoice ? { tool_choice: toolChoice } : {}),
+    metadata: { user_id: "operit-user" },
   };
 }
 


### PR DESCRIPTION
## Cache Improvements for Multi-Client Scenarios

This PR extracts cache-related improvements from my fork to contribute back upstream.

### Changes

**1. `applyRollingMessageCache` rewrite (`src/proxy/anthropicAdapter.ts`)**

Original behavior: only places a single `cache_control` marker at the window boundary (first user message when full window, or last user message when partial).

New behavior: distributes cache markers evenly across user messages, up to Anthropic's 4-marker limit (minus system-level markers). This improves cache hit rates in long conversations by creating multiple cache breakpoints.

**2. `metadata.user_id` added to Anthropic requests (`src/proxy/anthropicAdapter.ts`)**

Adds `metadata: { user_id: "operit-user" }` to both `buildAnthropicNativeRequest` and `buildAnthropicRequestFromAssembled` return objects. This enables Anthropic's persistent prompt cache feature across sessions.

**3. Volatile time/static context detection (`src/assembler/blocks.ts`)**

- `isVolatileTimeLine()`: recognizes additional time formats injected by Operit and similar clients:
  - Bracketed labels like `【当前时间】`, `【系统时间】`
  - Standalone date/date-time lines like `2026-06-28 20:45:42`
  - Day-of-week lines like `星期: 星期日`

- New `VOLATILE_SECTION_HEADER` constant + `splitClientSystemTexts()` enhancement:
  - Detects bracketed section headers (`【当前时间】`, `【相关记忆】`, `【动态上下文】`, `【当前位置】`, `【系统状态】`)
  - When matched, the entire section (until blank line) is treated as volatile
  - This prevents dynamic client-injected context from poisoning the stable Claude prompt cache anchor

### Why

When using Aelios with clients like Operit that inject dynamic context (current time, relevant memories, system status) as system message sections, the original `splitClientSystemTexts` would only catch single-line time references. Multi-line bracketed sections would leak into the stable `client_system` block, breaking cache whenever the dynamic content changed.

The rolling cache improvement also helps long conversations where the original single-marker approach missed cache opportunities for messages far from the boundary.

### Files Changed

- `src/assembler/blocks.ts` (+36 lines)
- `src/proxy/anthropicAdapter.ts` (+17/-14 lines)

No new dependencies. No environment variable changes. Backward compatible.