### PR TITLE
fix(memory): retry dream batches after truncated JSON

### DIFF
--- a/scripts/verify-vector-memory-write.mjs
+++ b/scripts/verify-vector-memory-write.mjs
@@ -77,7 +77,7 @@ assert.match(source, /if \(input\.status && record\.status !== input\.status\) c
 
 assert.match(searchSource, /function getLegacyFallbackLimit\(env: Env, topK: number\): number/);
 assert.match(searchSource, /function getLegacyFallbackScoreFactor\(env: Env\): number/);
-assert.match(searchSource, /const vectorTopK = Math\.min\(Math\.max\(input\.topK \* 3, input\.topK \+ legacyFallbackLimit\), 100\);/);
+assert.match(searchSource, /const vectorTopK = Math\.min\(Math\.max\(input\.topK \* 3, input\.topK \+ legacyFallbackLimit\), 50\);/);
 assert.match(searchSource, /const legacySlots = Math\.max\(0, Math\.min\(input\.topK - d1Records\.length, legacyFallbackLimit\)\);/);
 assert.match(searchSource, /score: record\.score \* getLegacyFallbackScoreFactor\(env\)/);
 assert.match(searchSource, /\)\.slice\(0, input\.topK\);/);
@@ -85,6 +85,8 @@ assert.match(searchSource, /\)\.slice\(0, input\.topK\);/);
 assert.match(digestSource, /const summary = \[`【\$\{input\.dateLabel\} 重要原文】`, reason \? `保存原因：\$\{reason\}` : ""\]/);
 assert.match(digestSource, /content: quote,\s+summary,/s);
 assert.match(digestSource, /if \(v2Enabled && strategy !== "legacy"\) \{\s+const page = await listMemoriesPage\(env\.DB,/s);
+assert.match(digestSource, /modelResult\.reason !== "model_invalid_json" \|\| modelResult\.finishReason !== "length"/);
+assert.match(digestSource, /messages = messages\.slice\(0, nextSize\);/);
 
 assert.match(recallSource, /function readRecallMinScore\(env: Env, override\?: number\): number/);
 assert.match(recallSource, /RECALL_MIN_SCORE \?\? 0\.15/);

--- a/src/memory/dailyDigest.ts
+++ b/src/memory/dailyDigest.ts
@@ -829,20 +829,18 @@ export async function runDailyMemoryDigest(
   }
 
   const maxMessages = readDreamMaxMessages(env);
-  const messages = await listMessagesByNamespaceInRange(env.DB, {
+  const fetchedMessages = await listMessagesByNamespaceInRange(env.DB, {
     namespace,
     startCreatedAt: startIso,
     endCreatedAt: endIso,
     afterCreatedAt: cursorState.after,
     limit: maxMessages
   });
-  if (messages.length === 0) {
+  if (fetchedMessages.length === 0) {
     await writeCursor(env.DB, cursorName, `done:${cursorState.after ?? startIso}`);
     return { ran: false, mode: "dream", date: dateLabel, reason: "no_messages", startIso, endIso, cursor };
   }
 
-  const lastMessage = messages[messages.length - 1];
-  const hasMore = messages.length >= maxMessages;
   const memoryContextLimit = readDreamMemoryContextLimit(env);
   const strategy = readDreamStrategy(env);
   const v2Enabled = isV2Enabled(env);
@@ -866,22 +864,43 @@ export async function runDailyMemoryDigest(
     console.error("dream: failed to list existing memories", error);
   }
   const cleanedEmptyMemories = v2Enabled && strategy === "review" ? 0 : await cleanEmptyMemories(env, namespace);
+  const excerptLimit = readDreamExcerptLimit(env);
+  const fetchedHasMore = fetchedMessages.length >= maxMessages;
 
-  const prompt = buildDigestPrompt({
-    dateLabel,
-    startIso,
-    endIso,
-    messages,
-    existingMemories,
-    excerptLimit: readDreamExcerptLimit(env),
-    hasMore
-  });
-  const modelResult = await callDigestModel(env, prompt, {
-    dateLabel,
-    messageCount: messages.length,
-    memoryCount: existingMemories.length,
-    hasMore
-  });
+  let messages = fetchedMessages;
+  let hasMore = fetchedHasMore;
+  let modelResult: DigestModelCallResult;
+  for (;;) {
+    const prompt = buildDigestPrompt({
+      dateLabel,
+      startIso,
+      endIso,
+      messages,
+      existingMemories,
+      excerptLimit,
+      hasMore
+    });
+    modelResult = await callDigestModel(env, prompt, {
+      dateLabel,
+      messageCount: messages.length,
+      memoryCount: existingMemories.length,
+      hasMore
+    });
+    if (modelResult.digest) break;
+    if (modelResult.reason !== "model_invalid_json" || modelResult.finishReason !== "length" || messages.length <= 1) break;
+
+    const nextSize = Math.max(1, Math.floor(messages.length / 2));
+    if (nextSize >= messages.length) break;
+    console.warn("dream: retrying with smaller batch after length-truncated JSON", {
+      date: dateLabel,
+      previousMessageCount: messages.length,
+      nextMessageCount: nextSize,
+      model: modelResult.model
+    });
+    messages = messages.slice(0, nextSize);
+    hasMore = true;
+  }
+
   const digest = modelResult.digest;
   if (!digest) {
     console.error("dream: model did not return valid JSON; cursor not advanced", {
@@ -903,6 +922,7 @@ export async function runDailyMemoryDigest(
       finishReason: modelResult.finishReason
     };
   }
+  const lastMessage = messages[messages.length - 1];
   const messageIds = messages.map((message) => message.id);
 
   // v2 path: fact_key upsert + L1 digest + longtail + yesterday_log


### PR DESCRIPTION
## Summary
- retry nightly dream batches with a smaller message slice when the model returns length-truncated invalid JSON
- preserve cursor semantics by advancing only to the last successfully processed message
- update the vector memory verification assertion for the current Vectorize topK=50 cap

## Production check
- Deployed with setup-cloudflare + wrangler deploy --keep-vars after confirming DB binding
- Manually reran 2026-06-29 dream; remaining 26 messages completed as 13 + 13
- D1 cursor is now done:2026-06-29T15:39:38.858Z with 0 remaining messages

## Verification
- npm run verify