### PR TITLE
fix(admin): allow deleting longtail fallback entries

### DIFF
--- a/scripts/verify-vector-memory-write.mjs
+++ b/scripts/verify-vector-memory-write.mjs
@@ -25,6 +25,9 @@ const extractSource = readFileSync(resolve(root, "src/memory/extractPipeline.ts"
 const indexSource = readFileSync(resolve(root, "src/index.ts"), "utf8");
 const wranglerSource = readFileSync(resolve(root, "wrangler.toml"), "utf8");
 const queueProducerSource = readFileSync(resolve(root, "src/queue/producer.ts"), "utf8");
+const dbV2Source = readFileSync(resolve(root, "src/db/v2.ts"), "utf8");
+const memoriesApiSource = readFileSync(resolve(root, "src/api/memories.ts"), "utf8");
+const adminSource = readFileSync(resolve(root, "src/api/admin.ts"), "utf8");
 
 function indexOfOrThrow(haystack, needle) {
   const index = haystack.indexOf(needle);
@@ -103,6 +106,8 @@ assert.match(wranglerSource, /EXTRACT_MODEL = "deepseek\/deepseek-v4-flash"/);
 assert.match(wranglerSource, /DEDUP_COSINE = "0\.9"/);
 assert.match(indexSource, /const EXTRACT_CRON = "0 \*\/4 \* \* \*"/);
 assert.match(indexSource, /runMemoryExtractionBatches\(env, namespace, \{ scheduledTime: controller\.scheduledTime \}\)/);
+assert.match(indexSource, /url\.pathname\.startsWith\("\/v1\/longtail\/"\)/);
+assert.match(indexSource, /handleLongtailApi\(request, env\)/);
 assert.match(queueProducerSource, /if \(isV2Enabled\(env\)\) return;/);
 assert.match(extractSource, /const DEFAULT_EXTRACT_MODEL = "deepseek\/deepseek-v4-flash"/);
 assert.match(extractSource, /const DEFAULT_DEDUP_COSINE = 0\.9/);
@@ -114,7 +119,14 @@ assert.match(extractSource, /getActiveMemoryByFactKey\(env\.DB, \{ namespace: in
 assert.match(extractSource, /await isSameFactByEmbedding\(env, \{/);
 assert.match(extractSource, /await supersedeMemory\(env, \{/);
 assert.match(extractSource, /findEmbeddingDuplicate\(env,/);
-assert.match(readFileSync(resolve(root, "src/db/v2.ts"), "utf8"), /await db\.batch\(\[ensureLifecycle, markSeen\]\);/);
+assert.match(dbV2Source, /await db\.batch\(\[ensureLifecycle, markSeen\]\);/);
+assert.match(dbV2Source, /export async function deleteLongtail/);
+assert.match(dbV2Source, /deleteByIds\(\[`lt_\$\{input\.id\}`\]\)/);
+assert.match(dbV2Source, /DELETE FROM longtail WHERE namespace = \? AND id = \?/);
+assert.match(memoriesApiSource, /export async function handleLongtailApi/);
+assert.match(memoriesApiSource, /const result = await deleteLongtail\(env, \{ namespace, id \}\);/);
+assert.match(adminSource, /\/v1\/longtail\/' \+ encodeURIComponent\(item\.id\)/);
+assert.doesNotMatch(adminSource, /x-show="item\.type !== 'longtail'"/);
 assert.match(digestSource, /v2 首次抽取由每 4 小时 extractor 负责/);
 assert.doesNotMatch(digestSource, /for \(const memory of digest\.memories_to_add \?\? \[\]\) \{\s+const factKey/s);
 assert.doesNotMatch(digestSource, /added \+= 0/);

--- a/src/api/admin.ts
+++ b/src/api/admin.ts
@@ -368,7 +368,7 @@ document.documentElement.dataset.theme = localStorage.getItem('aelios.admin.colo
             <article class="rounded-2xl border border-zinc-800 bg-zinc-900 p-4 shadow-sm">
               <div class="mb-2 flex flex-wrap items-center gap-2 text-xs text-zinc-400">
                 <span x-text="item.type || 'longtail'"></span><span x-text="item.status || item.source || ''"></span><span x-text="item.source || ''"></span>
-                <button x-show="item.type !== 'longtail'" type="button" @click="deleteWorldMemory(item)" class="tap ml-auto rounded-2xl border border-zinc-800 px-3 py-1 text-xs text-zinc-400 hover:border-coral">删除</button>
+                <button type="button" @click="deleteWorldMemory(item)" class="tap ml-auto rounded-2xl border border-zinc-800 px-3 py-1 text-xs text-zinc-400 hover:border-coral">删除</button>
               </div>
               <p class="whitespace-pre-wrap text-sm leading-7" x-text="item.content"></p>
             </article>
@@ -735,7 +735,19 @@ function memoryAdmin() {
       }
     },
     async deleteWorldMemory(item) {
-      await this.deleteMemory(item);
+      if (item.type !== 'longtail') {
+        await this.deleteMemory(item);
+        return;
+      }
+      if (!window.confirm('确认删除这条兜底大库条目？')) return;
+      try {
+        await this.request(this.withNamespace('/v1/longtail/' + encodeURIComponent(item.id)), { method: 'DELETE' });
+        await this.loadBoot();
+        if (this.moreView === 'world') await this.loadWorldFacts();
+        this.notify('兜底条目已删除');
+      } catch (error) {
+        this.notify(error.message);
+      }
     },
     async mergeDuplicate(memory) {
       if (!memory.target_id) {

--- a/src/api/memories.ts
+++ b/src/api/memories.ts
@@ -14,6 +14,7 @@ import {
   countMemoryCandidates,
   createPrecious,
   deleteGlossary,
+  deleteLongtail,
   deletePrecious,
   fetchMemoryLifecycleRows,
   getDigest,
@@ -523,6 +524,28 @@ export async function handleGlossaryApi(request: Request, env: Env): Promise<Res
   }
 
   return openAiError("Not found", 404);
+}
+
+export async function handleLongtailApi(request: Request, env: Env): Promise<Response> {
+  const auth = await authenticate(request, env);
+  if (!auth.ok) return openAiError("Unauthorized", 401, "authentication_error");
+
+  const scopeError = requireScope(auth.profile, "memory:write");
+  if (scopeError) return scopeError;
+
+  const url = new URL(request.url);
+  const namespace = resolveNamespace(auth.profile, url.searchParams.get("namespace"));
+  const parts = url.pathname.split("/").filter(Boolean);
+  const id = parts[2];
+
+  if (request.method !== "DELETE" || !id) return openAiError("Not found", 404);
+
+  const result = await deleteLongtail(env, { namespace, id });
+  if (result === "not_found") return openAiError("Longtail entry not found", 404);
+  if (result === "vector_error") {
+    return openAiError("Longtail vector delete failed", 503, "memory_error");
+  }
+  return json({ data: { id, deleted: true } });
 }
 
 async function createApprovedMemoryFromCandidate(

--- a/src/db/v2.ts
+++ b/src/db/v2.ts
@@ -384,6 +384,32 @@ export async function listLongtail(
   return result.results ?? [];
 }
 
+export async function deleteLongtail(
+  env: Env,
+  input: { namespace: string; id: string }
+): Promise<"deleted" | "not_found" | "vector_error"> {
+  const existing = await env.DB
+    .prepare("SELECT id FROM longtail WHERE namespace = ? AND id = ?")
+    .bind(input.namespace, input.id)
+    .first<{ id: string }>();
+  if (!existing) return "not_found";
+
+  if (env.VECTORIZE) {
+    try {
+      await env.VECTORIZE.deleteByIds([`lt_${input.id}`]);
+    } catch (error) {
+      console.error("longtail vector delete failed, keeping D1 row", { id: input.id, error });
+      return "vector_error";
+    }
+  }
+
+  await env.DB
+    .prepare("DELETE FROM longtail WHERE namespace = ? AND id = ?")
+    .bind(input.namespace, input.id)
+    .run();
+  return "deleted";
+}
+
 export interface MemoryTypeCount {
   type: string;
   count: number;

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import {
   handleMemories,
   handleMemoryBoot,
   handleMemoryCandidates,
+  handleLongtailApi,
   handlePrecious,
   handleSearchMemoriesApi
 } from "./api/memories";
@@ -101,6 +102,10 @@ export default {
 
     if (url.pathname === "/v1/glossary" || url.pathname.startsWith("/v1/glossary/")) {
       return handleGlossaryApi(request, env);
+    }
+
+    if (url.pathname.startsWith("/v1/longtail/")) {
+      return handleLongtailApi(request, env);
     }
 
     if (url.pathname === "/v1/candidates" || url.pathname.startsWith("/v1/candidates/")) {


### PR DESCRIPTION
## Summary
- show the delete button for longtail fallback entries in the admin world/longtail panel
- add DELETE /v1/longtail/:id with memory:write auth and namespace scoping
- delete the Vectorize lt_<id> mirror before removing the D1 longtail row, so stale fallback vectors do not reappear

## Production check
- deployed with setup-cloudflare + wrangler deploy --keep-vars; deployment has DB binding
- verified DELETE /v1/longtail/lt_nonexistent_codex_check returns the expected Longtail entry not found 404 without touching real entries

## Verification
- npm run verify