### PR TITLE
fix(memory): enforce canonical types + manual create form

### DIFF
--- a/scripts/verify-vector-memory-write.mjs
+++ b/scripts/verify-vector-memory-write.mjs
@@ -143,9 +143,9 @@ assert.match(adminSource, /@click="deleteSelectedWorldItems\(\)"/);
 assert.match(adminSource, /:key="worldItemKey\(item\)"/);
 assert.match(adminSource, /Promise\.allSettled\(batch\.map/);
 assert.doesNotMatch(adminSource, /x-show="item\.type !== 'longtail'"/);
-// Memory panel must surface every active type, not just a fixed canonical set,
-// and offer manual creation. Regression guard for "容量涨了但面板看不到" bug.
+// Memory panel: fixed canonical tabs + 全部 for legacy cleanup, and manual creation.
 assert.match(adminSource, /get memoryTypes\(\)/);
+assert.match(adminSource, /return \['all'\]\.concat\(this\.canonicalMemoryTypes\)/);
 assert.match(adminSource, /memoryTypeLabel\(type\)/);
 assert.match(adminSource, /memoryType && this\.memoryType !== 'all'/);
 assert.match(adminSource, /if \(type === 'all'\)/);
@@ -153,6 +153,22 @@ assert.match(adminSource, /openMemoryCreate\(\)/);
 assert.match(adminSource, /async createMemory\(\)/);
 assert.match(adminSource, /'\/v1\/memories'\), \{\s+method: 'POST'/s);
 assert.match(adminSource, /await crypto\.subtle\.digest\('SHA-1', data\)/);
+// Types are enforced at the write boundary — no free-form types allowed.
+assert.match(extractSource, /import \{ clampMemoryType \} from "\.\/canonicalTypes"/);
+assert.match(extractSource, /type: clampMemoryType\(readString\(raw\.type\)\)/);
+assert.match(extractSource, /type 只能从这 8 个里选/);
+assert.match(extractSource, /type: "fact"/);
+assert.match(dbV2Source, /import \{ clampMemoryType \} from "\.\.\/memory\/canonicalTypes"/);
+assert.match(dbV2Source, /clampMemoryType\(input\.type, "note"\)/);
+assert.match(dbV2Source, /clampMemoryType\(input\.type, "fact"\)/);
+assert.match(dbV2Source, /clampMemoryType\(input\.newType, "fact"\)/);
+assert.match(source, /import \{ clampMemoryType \} from "\.\/canonicalTypes"/);
+assert.match(source, /type: clampMemoryType\(input\.type, "note"\),/);
+assert.match(memoriesApiSource, /clampMemoryType\(readString\(body\.type\), "note"\)/);
+assert.match(memoriesApiSource, /clampMemoryType\(readString\(body\.type\) \|\| candidate\.type, "note"\)/);
+assert.match(digestSource, /memories_to_update 里的 type 只能从这 8 个里选/);
+assert.doesNotMatch(extractSource, /type: "project"/);
+assert.doesNotMatch(dbV2Source, /input\.newType \?\? "world_fact"/);
 assert.match(digestSource, /v2 首次抽取由每 4 小时 extractor 负责/);
 assert.doesNotMatch(digestSource, /for \(const memory of digest\.memories_to_add \?\? \[\]\) \{\s+const factKey/s);
 assert.doesNotMatch(digestSource, /added \+= 0/);

--- a/scripts/verify-vector-memory-write.mjs
+++ b/scripts/verify-vector-memory-write.mjs
@@ -143,6 +143,16 @@ assert.match(adminSource, /@click="deleteSelectedWorldItems\(\)"/);
 assert.match(adminSource, /:key="worldItemKey\(item\)"/);
 assert.match(adminSource, /Promise\.allSettled\(batch\.map/);
 assert.doesNotMatch(adminSource, /x-show="item\.type !== 'longtail'"/);
+// Memory panel must surface every active type, not just a fixed canonical set,
+// and offer manual creation. Regression guard for "容量涨了但面板看不到" bug.
+assert.match(adminSource, /get memoryTypes\(\)/);
+assert.match(adminSource, /memoryTypeLabel\(type\)/);
+assert.match(adminSource, /memoryType && this\.memoryType !== 'all'/);
+assert.match(adminSource, /if \(type === 'all'\)/);
+assert.match(adminSource, /openMemoryCreate\(\)/);
+assert.match(adminSource, /async createMemory\(\)/);
+assert.match(adminSource, /'\/v1\/memories'\), \{\s+method: 'POST'/s);
+assert.match(adminSource, /await crypto\.subtle\.digest\('SHA-1', data\)/);
 assert.match(digestSource, /v2 首次抽取由每 4 小时 extractor 负责/);
 assert.doesNotMatch(digestSource, /for \(const memory of digest\.memories_to_add \?\? \[\]\) \{\s+const factKey/s);
 assert.doesNotMatch(digestSource, /added \+= 0/);

--- a/src/api/admin.ts
+++ b/src/api/admin.ts
@@ -258,18 +258,69 @@ document.documentElement.dataset.theme = localStorage.getItem('aelios.admin.colo
             <h1 class="text-2xl font-semibold">重要记忆</h1>
             <p class="mt-1 text-sm text-zinc-400">L4 稳定事实、偏好、边界和决策。</p>
           </div>
-          <button type="button" @click="loadMemories()" class="tap rounded-2xl border border-zinc-800 px-4 text-sm transition duration-150 ease-in-out hover:border-coral">刷新</button>
+          <div class="flex flex-wrap items-center gap-2">
+            <button type="button" @click="openMemoryCreate()" class="tap inline-flex items-center gap-2 rounded-2xl bg-coral px-4 text-sm font-semibold text-zinc-950 transition duration-150 ease-in-out">
+              <i data-lucide="plus" class="h-4 w-4"></i><span>新增</span>
+            </button>
+            <button type="button" @click="loadMemories()" class="tap rounded-2xl border border-zinc-800 px-4 text-sm transition duration-150 ease-in-out hover:border-coral">刷新</button>
+          </div>
         </div>
 
         <div class="flex gap-2 overflow-x-auto pb-1">
           <template x-for="type in memoryTypes" :key="type">
             <button type="button" @click="memoryType = type; loadMemories()" class="choice-tab tap shrink-0 rounded-2xl border px-4 text-sm transition duration-150 ease-in-out hover:border-coral" :class="memoryType === type ? 'is-active' : ''">
-              <span x-text="type"></span>
+              <span x-text="memoryTypeLabel(type)"></span>
               <span class="ml-1 text-xs" x-text="typeCount(type) + '/' + typeLimit(type)"></span>
             </button>
           </template>
         </div>
 
+        <article x-show="memoryCreateOpen" class="rounded-2xl border border-zinc-800 bg-zinc-900 p-4 shadow-sm">
+          <div class="mb-3 flex items-center justify-between gap-3">
+            <div class="text-sm font-semibold">手工新增记忆</div>
+            <button type="button" @click="memoryCreateOpen = false" class="tap rounded-2xl border border-zinc-800 px-3 text-xs text-zinc-400 transition duration-150 ease-in-out hover:border-coral">关闭</button>
+          </div>
+          <div class="grid gap-3">
+            <div class="grid gap-2 md:grid-cols-[1fr_1fr]">
+              <label class="block">
+                <span class="text-xs text-zinc-400">类型</span>
+                <select x-model="memoryDraft.type" class="mt-1 h-11 w-full rounded-2xl border border-zinc-800 bg-[#0a0a0b] px-3 text-sm outline-none focus:border-coral">
+                  <template x-for="type in memoryTypes" :key="type">
+                    <option x-show="type !== 'all'" :value="type" x-text="type"></option>
+                  </template>
+                </select>
+              </label>
+              <label class="block">
+                <span class="text-xs text-zinc-400">fact_key（留空自动按内容生成）</span>
+                <input x-model="memoryDraft.fact_key" class="mt-1 h-11 w-full rounded-2xl border border-zinc-800 bg-[#0a0a0b] px-3 text-sm outline-none focus:border-coral" placeholder="如 preference:answer-style">
+              </label>
+            </div>
+            <label class="block">
+              <span class="text-xs text-zinc-400">内容</span>
+              <textarea x-model="memoryDraft.content" class="mt-1 min-h-28 w-full resize-y rounded-2xl border border-zinc-800 bg-[#0a0a0b] p-3 text-sm leading-7 text-zinc-100 outline-none focus:border-coral" placeholder="一句稳定、可复用的事实"></textarea>
+            </label>
+            <div class="grid gap-3 md:grid-cols-2">
+              <label class="block">
+                <span class="text-xs text-zinc-400">重要性 <span x-text="memoryDraft.importance.toFixed(2)"></span></span>
+                <input type="range" min="0" max="1" step="0.05" x-model.number="memoryDraft.importance" class="mt-2 w-full">
+              </label>
+              <label class="block">
+                <span class="text-xs text-zinc-400">置信度 <span x-text="memoryDraft.confidence.toFixed(2)"></span></span>
+                <input type="range" min="0" max="1" step="0.05" x-model.number="memoryDraft.confidence" class="mt-2 w-full">
+              </label>
+            </div>
+            <div class="flex justify-end gap-2">
+              <button type="button" @click="memoryCreateOpen = false" class="tap rounded-2xl border border-zinc-800 px-4 text-sm text-zinc-400 transition duration-150 ease-in-out hover:border-coral">取消</button>
+              <button type="button" @click="createMemory()" :disabled="saving" class="tap inline-flex items-center gap-2 rounded-2xl bg-coral px-4 text-sm font-semibold text-zinc-950 disabled:opacity-50">
+                <i data-lucide="save" class="h-4 w-4"></i><span>保存</span>
+              </button>
+            </div>
+          </div>
+        </article>
+
+        <template x-if="memories.length === 0">
+          <div class="rounded-2xl border border-zinc-800 bg-zinc-900 p-6 text-sm text-zinc-400">这个类型下还没有记忆。</div>
+        </template>
         <div class="grid gap-3 lg:grid-cols-2">
           <template x-for="memory in memories" :key="memory.id">
             <article class="rounded-2xl border border-zinc-800 bg-zinc-900 p-4 shadow-sm">
@@ -454,7 +505,7 @@ function memoryAdmin() {
       { id: 'world', label: '世界知识' },
       { id: 'maintenance', label: '维护' }
     ],
-    memoryTypes: ['fact', 'event', 'preference', 'relationship', 'boundary', 'habit', 'decision', 'note'],
+    canonicalMemoryTypes: ['fact', 'event', 'preference', 'relationship', 'boundary', 'habit', 'decision', 'note'],
     limits: { fact: 120, event: 80, preference: 80, relationship: 80, boundary: 80, habit: 80, decision: 80, note: 120 },
     page: 'today',
     moreView: 'precious',
@@ -475,7 +526,9 @@ function memoryAdmin() {
     worldItems: [],
     worldSelection: {},
     worldQuery: '',
-    memoryType: 'fact',
+    memoryType: 'all',
+    memoryCreateOpen: false,
+    memoryDraft: { type: 'fact', content: '', fact_key: '', importance: 0.7, confidence: 0.85 },
     glossaryDraft: { term: '', definition: '', aliasesText: '' },
     debugOutput: '尚未运行维护操作',
     toast: '',
@@ -600,7 +653,8 @@ function memoryAdmin() {
     },
     async loadMemories() {
       try {
-        const path = '/v1/memory?status=active&limit=100&type=' + encodeURIComponent(this.memoryType);
+        const typeParam = this.memoryType && this.memoryType !== 'all' ? '&type=' + encodeURIComponent(this.memoryType) : '';
+        const path = '/v1/memory?status=active&limit=100' + typeParam;
         const data = await this.request(this.withNamespace(path));
         this.memories = (data.data || []).map(function(item) {
           item.editing = false;
@@ -722,6 +776,53 @@ function memoryAdmin() {
       memory.editing = !memory.editing;
       memory.draft = { content: memory.content };
       this.icons();
+    },
+    openMemoryCreate() {
+      const fallback = this.memoryType && this.memoryType !== 'all' ? this.memoryType : 'fact';
+      this.memoryDraft = { type: fallback, content: '', fact_key: '', importance: 0.7, confidence: 0.85 };
+      this.memoryCreateOpen = true;
+      this.icons();
+    },
+    async ensureFactKey(type, content) {
+      const trimmed = (content || '').trim();
+      if (!trimmed) return null;
+      try {
+        const data = new TextEncoder().encode(type + ':' + trimmed);
+        const buf = await crypto.subtle.digest('SHA-1', data);
+        const hex = Array.from(new Uint8Array(buf)).map(function(b) { return b.toString(16).padStart(2, '0'); }).join('');
+        return 'manual:' + type + ':' + hex.slice(0, 10);
+      } catch (error) {
+        return 'manual:' + type + ':' + Date.now().toString(36);
+      }
+    },
+    async createMemory() {
+      const content = (this.memoryDraft.content || '').trim();
+      if (!content) { this.notify('内容不能为空'); return; }
+      const type = (this.memoryDraft.type || 'fact').trim() || 'fact';
+      let factKey = (this.memoryDraft.fact_key || '').trim();
+      if (!factKey) factKey = await this.ensureFactKey(type, content);
+      this.saving = true;
+      try {
+        await this.request(this.withNamespace('/v1/memories'), {
+          method: 'POST',
+          body: JSON.stringify({
+            namespace: this.namespace,
+            type: type,
+            content: content,
+            fact_key: factKey,
+            importance: Number(this.memoryDraft.importance),
+            confidence: Number(this.memoryDraft.confidence),
+            source: 'manual'
+          })
+        });
+        this.memoryCreateOpen = false;
+        this.memoryType = type;
+        await Promise.all([this.loadMemories(), this.loadBoot()]);
+        this.notify('已新增记忆');
+      } catch (error) {
+        this.notify(error.message);
+      }
+      this.saving = false;
     },
     async saveMemory(memory) {
       try {
@@ -962,12 +1063,31 @@ function memoryAdmin() {
         return [];
       }
     },
+    get memoryTypes() {
+      const rows = this.stats.memory_type_counts || [];
+      const seen = {};
+      const list = ['all'];
+      this.canonicalMemoryTypes.forEach(function(type) { seen[type] = true; list.push(type); });
+      rows.forEach(function(row) {
+        if (row.type && !seen[row.type]) { seen[row.type] = true; list.push(row.type); }
+      });
+      return list;
+    },
+    memoryTypeLabel(type) {
+      return type === 'all' ? '全部' : type;
+    },
     typeCount(type) {
       const rows = this.stats.memory_type_counts || [];
+      if (type === 'all') {
+        return rows.reduce(function(sum, row) { return sum + Number(row.count || 0); }, 0);
+      }
       const hit = rows.find(function(row) { return row.type === type; });
       return hit ? hit.count : 0;
     },
     typeLimit(type) {
+      if (type === 'all') {
+        return Object.keys(this.limits).reduce(function(sum, key) { return sum + this.limits[key]; }.bind(this), 0);
+      }
       return this.limits[type] || 100;
     },
     capacityLabel() {

--- a/src/api/admin.ts
+++ b/src/api/admin.ts
@@ -1064,14 +1064,9 @@ function memoryAdmin() {
       }
     },
     get memoryTypes() {
-      const rows = this.stats.memory_type_counts || [];
-      const seen = {};
-      const list = ['all'];
-      this.canonicalMemoryTypes.forEach(function(type) { seen[type] = true; list.push(type); });
-      rows.forEach(function(row) {
-        if (row.type && !seen[row.type]) { seen[row.type] = true; list.push(row.type); }
-      });
-      return list;
+      // 固定分类：全部 + 8 个 canonical 类型。类型在写入层已被 clampMemoryType
+      // 收敛，面板不再派生自由类型 tab。全部 用于排查历史脏数据。
+      return ['all'].concat(this.canonicalMemoryTypes);
     },
     memoryTypeLabel(type) {
       return type === 'all' ? '全部' : type;

--- a/src/api/memories.ts
+++ b/src/api/memories.ts
@@ -10,6 +10,7 @@ import { filterAndCompressMemoriesWithMeta } from "../memory/filter";
 import { formatMemoryPatch } from "../memory/inject";
 import { searchMemories, toMemoryApiRecord } from "../memory/search";
 import { deleteVectorMemory } from "../memory/vectorStore";
+import { clampMemoryType } from "../memory/canonicalTypes";
 import {
   countActiveMemoriesByType,
   countMemoryCandidates,
@@ -78,7 +79,7 @@ async function handleCreateMemory(
   if (!body) return openAiError("Request body must be a JSON object", 400);
 
   const content = readString(body.content);
-  const type = readString(body.type) || "note";
+  const type = clampMemoryType(readString(body.type), "note");
 
   if (!content) {
     return openAiError("content is required", 400);
@@ -621,7 +622,7 @@ export async function handleMemoryCandidates(request: Request, env: Env): Promis
   if (!candidate) return openAiError("Candidate not found", 404);
   const body = (await readJsonObject(request)) ?? {};
   const content = readString(body.content) || candidate.content;
-  const type = readString(body.type) || candidate.type;
+  const type = clampMemoryType(readString(body.type) || candidate.type, "note");
   const factKey = body.fact_key === null ? null : readString(body.fact_key) ?? candidate.fact_key;
   const confidence = readNumber(body.confidence, candidate.confidence);
   const importance = readNumber(body.importance, candidate.importance);

--- a/src/db/v2.ts
+++ b/src/db/v2.ts
@@ -7,6 +7,7 @@
 // 同步用 embedding.ts 的 upsertMemoryEmbedding / deleteMemoryEmbedding (已带 kind:"memory")。
 
 import { upsertMemoryEmbedding } from "../memory/embedding";
+import { clampMemoryType } from "../memory/canonicalTypes";
 import type { Env, MemoryLifecycleRow, MemoryRecord } from "../types";
 import { newId } from "../utils/ids";
 import { nowIso } from "../utils/time";
@@ -509,7 +510,7 @@ export async function createMemoryCandidate(
   const record: MemoryCandidateRow = {
     id,
     namespace: input.namespace,
-    type: input.type || "note",
+    type: clampMemoryType(input.type, "note"),
     content: input.content,
     fact_key: input.factKey ?? null,
     confidence: input.confidence ?? 0.5,
@@ -701,7 +702,7 @@ export async function upsertMemoryByFactKey(
       )
       .bind(
         input.content,
-        input.type ?? "fact",
+        clampMemoryType(input.type, "fact"),
         input.importance ?? 0.6,
         input.confidence ?? 0.8,
         JSON.stringify(input.tags ?? []),
@@ -736,7 +737,7 @@ export async function upsertMemoryByFactKey(
     .bind(
       id,
       input.namespace,
-      input.type ?? "fact",
+      clampMemoryType(input.type, "fact"),
       input.content,
       input.importance ?? 0.6,
       input.confidence ?? 0.8,
@@ -879,7 +880,7 @@ export async function supersedeMemory(
     .bind(
       nextId,
       input.namespace,
-      input.newType ?? "world_fact",
+      clampMemoryType(input.newType, "fact"),
       input.newContent,
       input.importance ?? 0.6,
       input.confidence ?? 0.8,

--- a/src/memory/canonicalTypes.ts
+++ b/src/memory/canonicalTypes.ts
@@ -1,0 +1,31 @@
+// 长期记忆只允许这 8 个固定类型。抽取器、dream、手工新增、候选审核、
+// upsert/supersede 全部在写入边界收敛到这个枚举，不允许自由类型。
+// 面板按这 8 个类型分 tab 展示；world_fact / precious 走各自独立页面，
+// 不进这个枚举。
+export const CANONICAL_MEMORY_TYPES = [
+  "fact",
+  "event",
+  "preference",
+  "relationship",
+  "boundary",
+  "habit",
+  "decision",
+  "note"
+] as const;
+
+export type CanonicalMemoryType = (typeof CANONICAL_MEMORY_TYPES)[number];
+
+const CANONICAL_SET = new Set<string>(CANONICAL_MEMORY_TYPES);
+
+/**
+ * 把任意 type 收敛到固定枚举。非空但不在枚举里的 → fallback。
+ * 大小写无关。写入层调用，保证库里不会出现自由类型。
+ */
+export function clampMemoryType(
+  type: string | null | undefined,
+  fallback: CanonicalMemoryType = "fact"
+): CanonicalMemoryType {
+  const trimmed = (type || "").trim().toLowerCase();
+  if (trimmed && CANONICAL_SET.has(trimmed)) return trimmed as CanonicalMemoryType;
+  return fallback;
+}

--- a/src/memory/dailyDigest.ts
+++ b/src/memory/dailyDigest.ts
@@ -473,6 +473,7 @@ function buildDigestPrompt(input: {
     "- v2 下 important_excerpts 只会进入人工审核候选，不会自动写入长期记忆。",
     "- memories_to_add 保留兼容字段，v2 下默认输出空数组。",
     "- memories_to_update 只针对给出的旧记忆 id。",
+    "- memories_to_update 里的 type 只能从这 8 个里选：fact、event、preference、relationship、boundary、habit、decision、note；项目进展归 fact，承诺/决定归 decision。绝不输出 project、world_fact 等其他值。",
     "- memories_to_delete 只删除空、重复、明显过期或被新信息否定的旧记忆。",
     "- 控制总输出长度，宁可少写也不要输出超长 JSON。",
     "",
@@ -495,7 +496,7 @@ function buildDigestPrompt(input: {
         {
           target_id: "mem_x",
           content: "更新后的旧记忆正文",
-          type: "project",
+          type: "fact",
           importance: 0.88,
           confidence: 0.9,
           tags: ["project"]

--- a/src/memory/extractPipeline.ts
+++ b/src/memory/extractPipeline.ts
@@ -12,6 +12,7 @@ import type { Env, MessageRecord, OpenAIChatRequest, OpenAIChatResponse } from "
 import { createEmbedding } from "./embedding";
 import { type ExtractedMemory } from "./extract";
 import { createVectorMemory } from "./vectorStore";
+import { clampMemoryType } from "./canonicalTypes";
 import { isV2Enabled } from "./v2/recall";
 
 const DEFAULT_EXTRACT_MODEL = "deepseek/deepseek-v4-flash";
@@ -168,7 +169,7 @@ function normalizeCandidate(item: unknown): ExtractedMemory | null {
   const content = readString(raw.content);
   if (!content || content.length > 1000) return null;
   return {
-    type: readString(raw.type) || "note",
+    type: clampMemoryType(readString(raw.type)),
     content,
     importance: clampScore(raw.importance, 0.65),
     confidence: clampScore(raw.confidence, 0.82),
@@ -209,14 +210,15 @@ function buildExtractPrompt(messages: MessageRecord[]): string {
     "- 只有用户明确说出、确认、长期表现出的事实，才能写成关于用户的记忆。",
     "- 关于用户的记忆，优先写成“你……”。关于我应遵守的长期方式，写成“我需要……”。",
     "- 每条 content 必须是一句自然短句。",
-    "- 稳定事实必须尽量给 fact_key，格式为小写 ASCII，例如 project:aelios-memory-v2、preference:answer-style、boundary:no-system-records。",
+    "- type 只能从这 8 个里选：fact、event、preference、relationship、boundary、habit、decision、note。绝不输出 project、world_fact、commitment 等其他值；项目进展归 fact，承诺/决定归 decision，习惯归 habit。",
+    "- 稳定事实必须尽量给 fact_key，格式为小写 ASCII，例如 project:aelios-memory-v2、preference:answer-style、boundary:no-system-records。fact_key 是分组键，跟 type 无关，可以带 project: preference: 等前缀。",
     "",
     "输出格式：",
     JSON.stringify({
       memories: [
         {
           content: "你正在把 Aelios v2 记忆写入拆成即时捕获、小批抽取和夜间整理三档。",
-          type: "project",
+          type: "fact",
           fact_key: "project:aelios-memory-v2-write-pipeline",
           importance: 0.86,
           confidence: 0.92,

--- a/src/memory/vectorStore.ts
+++ b/src/memory/vectorStore.ts
@@ -2,6 +2,7 @@ import type { Env, MemoryApiRecord, MemoryRecord } from "../types";
 import { newId } from "../utils/ids";
 import { nowIso } from "../utils/time";
 import { createEmbedding } from "./embedding";
+import { clampMemoryType } from "./canonicalTypes";
 
 type MetadataMap = Record<string, unknown>;
 
@@ -355,7 +356,7 @@ export async function createVectorMemory(env: Env, input: VectorMemoryInput): Pr
   const now = nowIso();
   const normalized = {
     namespace: input.namespace,
-    type: input.type || "note",
+    type: clampMemoryType(input.type, "note"),
     content,
     summary: input.summary ?? null,
     importance: clampScore(input.importance, 0.5),


### PR DESCRIPTION
## Summary

Per feedback: **不允许产出自由类型**。Flip the earlier approach — instead of teaching the panel to display free-form types, prevent free-form types from being written at all.

### 1. Enforce canonical types at the write boundary
New \`src/memory/canonicalTypes.ts\` exports the fixed 8-type enum and \`clampMemoryType()\`. The clamp is applied at every write path so no free-form type can enter the store:

- \`extractPipeline\` \`normalizeCandidate\` + prompt (example is now \`type: \"fact\"\`; the prompt enumerates the 8 allowed types and explicitly forbids \`project\`/\`world_fact\`/\`commitment\` etc.; project progress → \`fact\`, commitments → \`decision\`, habits → \`habit\`).
- \`dailyDigest\` dream prompt + \`memories_to_update\`.
- \`db/v2\` \`upsertMemoryByFactKey\` / \`supersedeMemory\` (default \`world_fact\` → \`fact\`) / \`createMemoryCandidate\`.
- \`memory/vectorStore\` \`createVectorMemory\`.
- \`api/memories\` REST v2 upsert + candidate approve/merge/supersede.

\`fact_key\` is unaffected — it's a separate grouping key and may still carry \`project:\`/\`preference:\` prefixes.

### 2. Panel: fixed canonical tabs
Reverted the dynamic-tab experiment. Tabs are now the fixed canonical 8 + a **全部** tab (kept so any pre-existing free-form memories can be found and cleaned up manually). Default tab is 全部.

### 3. Manual create-memory form (requirement #2)
\"+ 新增\" button on the memory page: type (select from the 8 canonical only) / content / fact_key / importance / confidence → \`POST /v1/memories\`. Blank \`fact_key\` auto-generates \`manual:<type>:<sha1(type:content)[:10]>\` so re-adding the same content upserts instead of duplicating.

### 4. Carried: ignore stale longtail vectors
Includes the previously-unmerged \`fix(memory): ignore stale longtail vectors\` (recall skips longtail vectors whose D1 row is gone).

## Notes
- Existing free-form memories already in D1 are **not** migrated. The 全部 tab surfaces them for manual cleanup. Going forward no new free-form types can be written.
- \`world_fact\` / \`precious\` remain valid for their own pages (world knowledge / precious) and are not part of the L4 memory enum.

## Test plan
- [x] \`npm run verify\` → 177 passed (assertions guard clamp at every write path, prompt constraint, panel fixed tabs, create flow)
- [x] \`verify-extract-pipeline\` / \`verify-cache-strategy\` pass
- [x] \`tsc --noEmit\` clean, no lint errors
- [ ] Manual: create a memory via the form with a non-canonical type attempt → confirm it's clamped to a canonical type in the list.
- [ ] Manual: confirm a new 4h extractor run only produces canonical types.