### PR TITLE
fix(memory): keep D1 IN-clause batches under the 100-variable limit

### DIFF
--- a/scripts/verify-assembler.mjs
+++ b/scripts/verify-assembler.mjs
@@ -2464,7 +2464,7 @@ const IDEMPOTENCY_KEYS_RETENTION_DAYS = 7;
 const MEMORY_ACTIVE_EXPIRY_DAYS = 180;
 const MEMORY_HARD_DELETE_DAYS = 30;
 const THROTTLE_HOURS = 24;
-const RETENTION_BATCH_SIZE = 100;
+const RETENTION_BATCH_SIZE = 90;
 
 function daysAgo(days) {
   return new Date(Date.now() - days * 86_400_000).toISOString();
@@ -2703,7 +2703,7 @@ check("retention constants are correct", () => {
   assert.strictEqual(MEMORY_ACTIVE_EXPIRY_DAYS, 180);
   assert.strictEqual(MEMORY_HARD_DELETE_DAYS, 30);
   assert.strictEqual(THROTTLE_HOURS, 24);
-  assert.strictEqual(RETENTION_BATCH_SIZE, 100);
+  assert.strictEqual(RETENTION_BATCH_SIZE, 90);
 });
 
 check("full lifecycle: active → expired → hard-deletable chain", () => {
@@ -2869,40 +2869,40 @@ check("legacy fallback: mixed — active D1 returns as d1Record, expired blocks 
 
 // --- Batch processing ---
 
-check("batch: RETENTION_BATCH_SIZE is 100", () => {
-  assert.strictEqual(RETENTION_BATCH_SIZE, 100);
+check("batch: RETENTION_BATCH_SIZE is 90", () => {
+  assert.strictEqual(RETENTION_BATCH_SIZE, 90);
 });
 
-check("batch: 250 ids split into 3 batches (100+100+50)", () => {
+check("batch: 250 ids split into 3 batches (90+90+70)", () => {
   const ids = Array.from({ length: 250 }, (_, i) => `id_${i}`);
   const batches = [];
   for (let i = 0; i < ids.length; i += RETENTION_BATCH_SIZE) {
     batches.push(ids.slice(i, i + RETENTION_BATCH_SIZE));
   }
   assert.strictEqual(batches.length, 3);
-  assert.strictEqual(batches[0].length, 100);
-  assert.strictEqual(batches[1].length, 100);
-  assert.strictEqual(batches[2].length, 50);
+  assert.strictEqual(batches[0].length, 90);
+  assert.strictEqual(batches[1].length, 90);
+  assert.strictEqual(batches[2].length, 70);
 });
 
-check("batch: 100 ids fit in exactly 1 batch", () => {
-  const ids = Array.from({ length: 100 }, (_, i) => `id_${i}`);
+check("batch: 90 ids fit in exactly 1 batch", () => {
+  const ids = Array.from({ length: 90 }, (_, i) => `id_${i}`);
   const batches = [];
   for (let i = 0; i < ids.length; i += RETENTION_BATCH_SIZE) {
     batches.push(ids.slice(i, i + RETENTION_BATCH_SIZE));
   }
   assert.strictEqual(batches.length, 1);
-  assert.strictEqual(batches[0].length, 100);
+  assert.strictEqual(batches[0].length, 90);
 });
 
-check("batch: 101 ids split into 2 batches (100+1)", () => {
-  const ids = Array.from({ length: 101 }, (_, i) => `id_${i}`);
+check("batch: 91 ids split into 2 batches (90+1)", () => {
+  const ids = Array.from({ length: 91 }, (_, i) => `id_${i}`);
   const batches = [];
   for (let i = 0; i < ids.length; i += RETENTION_BATCH_SIZE) {
     batches.push(ids.slice(i, i + RETENTION_BATCH_SIZE));
   }
   assert.strictEqual(batches.length, 2);
-  assert.strictEqual(batches[0].length, 100);
+  assert.strictEqual(batches[0].length, 90);
   assert.strictEqual(batches[1].length, 1);
 });
 
@@ -2917,9 +2917,17 @@ check("batch: empty ids produce 0 batches", () => {
 
 check("batch: stats accumulate across batches", () => {
   // Simulates: each batch returns a count, stats sum them
-  const batchResults = [100, 100, 50];
+  const batchResults = [90, 90, 70];
   const total = batchResults.reduce((sum, n) => sum + n, 0);
   assert.strictEqual(total, 250);
+});
+
+check("batch: D1 bind limit — IN clause + 1 leading param stays <= 100", () => {
+  // D1 limits each statement to 100 bound variables. Queries like
+  //   DELETE FROM memories WHERE namespace = ? AND id IN (?, ?, ...)
+  // bind 1 leading param + N ids. The batch size must keep 1 + N <= 100.
+  assert.ok(RETENTION_BATCH_SIZE + 1 <= 100, "RETENTION_BATCH_SIZE must leave room for the leading namespace param");
+  assert.ok(RETENTION_BATCH_SIZE <= 99, "RETENTION_BATCH_SIZE must be <= 99 to stay under D1's 100-variable limit");
 });
 
 check("batch: expireOldMemories returns expired refs with vector_ids", () => {
@@ -2948,8 +2956,8 @@ check("batch: Vectorize deleteByIds should be batched like hardDeleteMemories", 
     batches.push(vectorIds.slice(i, i + RETENTION_BATCH_SIZE));
   }
   assert.strictEqual(batches.length, 2);
-  assert.strictEqual(batches[0].length, 100);
-  assert.strictEqual(batches[1].length, 50);
+  assert.strictEqual(batches[0].length, 90);
+  assert.strictEqual(batches[1].length, 60);
 });
 
 // ---------------------------------------------------------------------------

--- a/src/db/retention.ts
+++ b/src/db/retention.ts
@@ -1,10 +1,14 @@
 import { nowIso } from "../utils/time";
 
 // ---------------------------------------------------------------------------
-// Batch size for SQL IN clauses and Vectorize deleteByIds
+// Batch size for SQL IN clauses and Vectorize deleteByIds.
+// D1 limits each statement to 100 bound variables. Queries here bind an extra
+// leading param (namespace) on top of the id placeholders, so a batch of N ids
+// binds N+1 variables. Keep the batch size below 99 to stay safely under the
+// limit; 90 leaves headroom for any future extra params.
 // ---------------------------------------------------------------------------
 
-export const RETENTION_BATCH_SIZE = 100;
+export const RETENTION_BATCH_SIZE = 90;
 
 // ---------------------------------------------------------------------------
 // messages: delete rows older than cutoff

--- a/src/db/v2.ts
+++ b/src/db/v2.ts
@@ -156,14 +156,19 @@ export async function markPreciousInjected(
   db: D1Database,
   input: { namespace: string; ids: string[] }
 ): Promise<void> {
-  if (input.ids.length === 0) return;
-  const placeholders = input.ids.map(() => "?").join(", ");
-  await db
-    .prepare(
-      `UPDATE precious SET last_injected_at = ? WHERE namespace = ? AND id IN (${placeholders})`
-    )
-    .bind(nowIso(), input.namespace, ...input.ids)
-    .run();
+  const ids = uniqueStrings(input.ids);
+  if (ids.length === 0) return;
+  const stamp = nowIso();
+  for (let i = 0; i < ids.length; i += SQLITE_BIND_BATCH_SIZE) {
+    const batch = ids.slice(i, i + SQLITE_BIND_BATCH_SIZE);
+    const placeholders = batch.map(() => "?").join(", ");
+    await db
+      .prepare(
+        `UPDATE precious SET last_injected_at = ? WHERE namespace = ? AND id IN (${placeholders})`
+      )
+      .bind(stamp, input.namespace, ...batch)
+      .run();
+  }
 }
 
 // =====================================================================
@@ -643,7 +648,11 @@ export interface MemoryV2Patch {
   validAsOf?: string | null;
 }
 
-const SQLITE_BIND_BATCH_SIZE = 100;
+// D1 limits each statement to 100 bound variables. Some batched queries bind
+// an extra leading param (e.g. last_injected_at) on top of the id placeholders,
+// so N ids bind N+1 variables. Keep the batch size under 99 to stay safe; 90
+// leaves headroom for any future extra params.
+const SQLITE_BIND_BATCH_SIZE = 90;
 
 function uniqueStrings(values: string[]): string[] {
   return [...new Set(values.filter((value) => value.trim()))];

--- a/src/index.ts
+++ b/src/index.ts
@@ -166,11 +166,21 @@ export default {
     }
 
     if (shouldRunDailyMaintenance) {
+      // Run dream and retention as independent tasks. Retention is best-effort
+      // cleanup: if it throws (e.g. a transient D1 error), it must NOT take the
+      // dream down with it — otherwise the dream's cursor never advances and
+      // the whole nightly maintenance silently fails. So retention gets its own
+      // .catch that swallows the rejection into a logged result, and dream is
+      // a separate top-level task that settles on its own.
+      tasks.push(runDailyMemoryDigestBatches(env, namespace));
       tasks.push(
-        Promise.all([
-          runDailyMemoryDigestBatches(env, namespace),
-          runMemoryRetention(env, namespace)
-        ]).then(([digest, retention]) => ({ digest, retention }))
+        runMemoryRetention(env, namespace).then(
+          (retention) => ({ ok: true as const, retention }),
+          (error) => {
+            console.error("scheduled memory retention failed", { namespace, error: String(error) });
+            return { ok: false as const, error: String(error) };
+          }
+        )
       );
     }
 


### PR DESCRIPTION
## Summary

The nightly dream cron (`10 20 * * *`, i.e. 04:10 SGT) had been firing but ending in **error** without advancing the dream cursor, so the nightly digest silently stopped running — only manual `/v1/memories/dream` triggers completed it.

Cloudflare cron history showed the 20:10 UTC fire ran for 163s and ended `error`. Observability logs pinned the cause:

```
20:10:11  error   10 20 * * *
20:10:31          dream: calling model
20:10:49          D1_ERROR: too many SQL variables at offset 349: SQLITE_ERROR
```

### Root cause

D1 limits each statement to **100 bound variables**. The batch helpers used a batch size of 100 and then bound an extra leading param on top of the id placeholders, so a full batch bound **101 variables** and threw:

- `DELETE FROM memories WHERE namespace = ? AND id IN (100 × ?)` → 101 vars (`RETENTION_BATCH_SIZE`)
- `UPDATE memory_lifecycle SET last_injected_at = ? WHERE memory_id IN (100 × ?)` → 101 vars (`SQLITE_BIND_BATCH_SIZE`)

That rejection poisoned `Promise.all([dream, retention])` in the scheduled handler, aborting the still-in-flight dream model call before it could write its `done:` cursor — which is exactly why the cursor only ever got marked `done` by manual triggers.

### Changes

- `RETENTION_BATCH_SIZE` and `SQLITE_BIND_BATCH_SIZE`: `100 → 90`. Pure DB-write chunking (one or two extra round-trips for large deletions); **no effect on the 40-message LLM batch or memory quality**.
- `markPreciousInjected`: batched (was unbounded; would overflow once a user has ≥ 99 pinned memories).
- Scheduled handler: decouple retention from dream. Retention is now a standalone best-effort task with its own `.catch`, so a retention failure can no longer reject the dream task and abort the digest.
- `verify-assembler`: updated mirrored batch-size assertions and added a contract check that `RETENTION_BATCH_SIZE` stays `≤ 99` so the off-by-one cannot silently regress.

## Test plan

- [x] `npm run verify` — 178 passed
- [x] `scripts/verify-extract-pipeline.mjs` — passed
- [x] `scripts/verify-cache-strategy.mjs` — passed
- [x] `scripts/verify-vector-memory-write.mjs` — passed
- [x] `tsc --noEmit` — clean
- [ ] After merge/deploy, confirm the next 20:10 UTC cron marks `dream:default:<date>` `done:` automatically (no manual trigger needed) and the Cloudflare cron row shows success instead of error.

Made with [Cursor](https://cursor.com)