### PR TITLE
fix(memory): 止住换题噪音，接通“请记住”，补上 Dream 写入断点

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,8 +45,8 @@ MEMORY_ZONE_CAP=0
 # true = 丢弃没有有效 D1 记录背书的 Vectorize 命中（清理 legacy 孤儿向量），默认 false 保持现状
 RECALL_REQUIRE_D1_BACKING=false
 
-# --- 候选队列自动评审 (judge)，默认关闭；开启后 cron 抽取批次后跑一轮自动评分 ---
-CANDIDATE_JUDGE_ENABLED=false
+# --- 候选队列自动评审 (judge)，默认开启；填 false 才回到全部人工批准 ---
+CANDIDATE_JUDGE_ENABLED=true
 JUDGE_MODEL=deepseek/deepseek-v4-flash
 JUDGE_MAX_CANDIDATES=20
 # judge 评分阈值：>= APPROVE_MIN 自动入库，<= DISCARD_MAX 自动丢弃，中间留人工

--- a/migrations/0014_quote_fts.sql
+++ b/migrations/0014_quote_fts.sql
@@ -1,0 +1,17 @@
+-- Searchable original utterances and memory text.
+-- fts_body is pre-tokenized (CJK bigrams + latin words) so write and query share one tokenizer.
+-- D1 ships FTS5; if a local sqlite build lacks it, quote search falls back to LIKE.
+
+CREATE VIRTUAL TABLE IF NOT EXISTS message_fts USING fts5(
+  fts_body,
+  namespace UNINDEXED,
+  message_id UNINDEXED,
+  tokenize = "unicode61 remove_diacritics 2"
+);
+
+CREATE VIRTUAL TABLE IF NOT EXISTS memory_fts USING fts5(
+  fts_body,
+  namespace UNINDEXED,
+  memory_id UNINDEXED,
+  tokenize = "unicode61 remove_diacritics 2"
+);

--- a/src/api/dream.ts
+++ b/src/api/dream.ts
@@ -1,6 +1,7 @@
 import { authenticate } from "../auth/apiKey";
 import { listDreamRunsForNamespace } from "../db/dreamRuns";
 import { listJudgedCandidatesInRange, listMemoriesCreatedInRange, listMemoriesGoneDormantInRange } from "../db/v2";
+import { runCandidateJudge } from "../memory/candidateJudge";
 import {
   countRawMessagesForDateLabel,
   getDateLabelsLookback,
@@ -104,6 +105,17 @@ export async function handleDreamRun(request: Request, env: Env): Promise<Respon
       dry_run: dryRun,
       result
     };
+
+    if (!dryRun) {
+      try {
+        response.candidate_judge = await runCandidateJudge(env, namespace);
+      } catch (error) {
+        response.candidate_judge = {
+          ran: false,
+          error: error instanceof Error ? error.message : String(error)
+        };
+      }
+    }
 
     if (dryRun && result.ran) {
       if ("proposal" in result && result.proposal) response.proposal = result.proposal;

--- a/src/api/models.ts
+++ b/src/api/models.ts
@@ -2,20 +2,8 @@ import { authenticate } from "../auth/apiKey";
 import type { Env } from "../types";
 import { json, openAiError } from "../utils/json";
 import { findIdentity, loadConfig } from "../gateway/config";
+import { catalogUrl } from "../gateway/upstream";
 
-
-/** Models catalog URL for any accepted address form: account ID, legacy gateway URL
- *  (with or without /compat), legacy REST base, or a custom OpenAI-compatible base. */
-function catalogUrl(address: string, gatewayId: string): string {
-  if (/^[a-f0-9]{32}$/i.test(address))
-    return `https://gateway.ai.cloudflare.com/v1/${address}/${gatewayId}/compat/models`;
-  const base = address.replace(/\/+$/, "");
-  const gw = base.match(/^https:\/\/gateway\.ai\.cloudflare\.com\/v1\/([a-f0-9]{32})\/([^/]+?)(?:\/compat)?$/i);
-  if (gw) return `https://gateway.ai.cloudflare.com/v1/${gw[1]}/${gw[2]}/compat/models`;
-  const rest = base.match(/^https:\/\/api\.cloudflare\.com\/client\/v4\/accounts\/([a-f0-9]{32})\/ai\/v1$/i);
-  if (rest) return `https://gateway.ai.cloudflare.com/v1/${rest[1]}/${gatewayId}/compat/models`;
-  return `${base}/models`;
-}
 /** The upstream owns the real catalog; local main models are only hints when it cannot answer. */
 export async function handleModels(request: Request, env: Env, slug: string | null = null): Promise<Response> {
   const auth = await authenticate(request, env);
@@ -33,7 +21,7 @@ export async function handleModels(request: Request, env: Env, slug: string | nu
   const address = config.upstream?.address?.trim() || env.AI_GATEWAY_BASE_URL || env.CLOUDFLARE_ACCOUNT_ID || "";
   let reason = !token ? "no-token" : !address ? "no-address" : "";
   if (!reason) {
-    const url = catalogUrl(address, env.AI_GATEWAY_ID || "default");
+    const url = catalogUrl(env, config);
     try {
       const upstream = await fetch(url, { headers: { authorization: `Bearer ${token}` }, signal: request.signal });
       if (upstream.ok) return new Response(upstream.body, { status: 200, headers: {

--- a/src/db/memories.ts
+++ b/src/db/memories.ts
@@ -1,4 +1,5 @@
 import type { MemoryLifecycleRow, MemoryRecord } from "../types";
+import { searchFtsIds } from "../memory/fts";
 import { newId } from "../utils/ids";
 import { nowIso } from "../utils/time";
 
@@ -367,7 +368,15 @@ export async function searchMemoriesByText(
     clauses.push("(content LIKE ? ESCAPE '\\' OR summary LIKE ? ESCAPE '\\')");
     binds.push(like, like);
   }
-  if (clauses.length > 0) {
+  const ftsIds = tokens.length > 0
+    ? await searchFtsIds(db, "memory_fts", "memory_id", { namespace: input.namespace, tokens, limit: input.limit })
+    : [];
+  if (ftsIds.length > 0) {
+    sql += ` AND (id IN (${ftsIds.map(() => "?").join(", ")})`;
+    binds.push(...ftsIds);
+    if (clauses.length > 0) sql += ` OR (${clauses.join(" OR ")})`;
+    sql += ")";
+  } else if (clauses.length > 0) {
     sql += ` AND (${clauses.join(" OR ")})`;
   }
 

--- a/src/db/messages.ts
+++ b/src/db/messages.ts
@@ -150,7 +150,7 @@ export async function getMessagesByIds(
       `SELECT id, conversation_id, namespace, role, content, source, created_at
        FROM messages
        WHERE namespace = ? AND id IN (${placeholders})
-       ORDER BY created_at ASC`
+       ORDER BY created_at ASC, id ASC`
     )
     .bind(input.namespace, ...input.ids)
     .all<MessageRecord>();
@@ -200,11 +200,26 @@ export async function listMessagesByNamespace(
     binds.push(afterCreatedAt);
   }
 
-  sql += ` ORDER BY created_at ASC LIMIT ?`;
+  sql += ` ORDER BY created_at ASC, id ASC LIMIT ?`;
   binds.push(limit);
 
   const result = await db.prepare(sql).bind(...binds).all<MessageRecord>();
   return result.results ?? [];
+}
+
+function appendAfterCursor(
+  sql: string,
+  binds: unknown[],
+  afterCreatedAt?: string | null,
+  afterId?: string | null
+): string {
+  if (!afterCreatedAt) return sql;
+  if (afterId) {
+    binds.push(afterCreatedAt, afterCreatedAt, afterId);
+    return `${sql} AND (created_at > ? OR (created_at = ? AND id > ?))`;
+  }
+  binds.push(afterCreatedAt);
+  return `${sql} AND created_at > ?`;
 }
 
 export async function listMessagesByNamespaceInRange(
@@ -214,6 +229,7 @@ export async function listMessagesByNamespaceInRange(
     startCreatedAt: string;
     endCreatedAt: string;
     afterCreatedAt?: string | null;
+    afterId?: string | null;
     limit: number;
   }
 ): Promise<MessageRecord[]> {
@@ -224,13 +240,8 @@ export async function listMessagesByNamespaceInRange(
                AND created_at >= ?
                AND created_at < ?`;
   const binds: unknown[] = [input.namespace, input.startCreatedAt, input.endCreatedAt];
-
-  if (input.afterCreatedAt) {
-    sql += ` AND created_at > ?`;
-    binds.push(input.afterCreatedAt);
-  }
-
-  sql += ` ORDER BY created_at ASC LIMIT ?`;
+  sql = appendAfterCursor(sql, binds, input.afterCreatedAt, input.afterId);
+  sql += ` ORDER BY created_at ASC, id ASC LIMIT ?`;
   binds.push(input.limit);
 
   const result = await db.prepare(sql).bind(...binds).all<MessageRecord>();

--- a/src/db/v2/memories.ts
+++ b/src/db/v2/memories.ts
@@ -1,4 +1,5 @@
 import { upsertMemoryEmbedding } from "../../memory/embedding";
+import { upsertMemoryFts } from "../../memory/fts";
 import { clampMemoryType } from "../../memory/canonicalTypes";
 import type {
   Env,
@@ -238,6 +239,7 @@ export async function upsertMemoryByFactKey(
       .bind(input.factKey, input.validAsOf ?? null, now, existing.id)
       .run();
     await syncMemoryVector(env, { namespace: input.namespace, id: existing.id });
+    await upsertMemoryFts(env.DB, { namespace: input.namespace, memoryId: existing.id, content: input.content });
     return { id: existing.id, created: false };
   }
 
@@ -281,6 +283,7 @@ export async function upsertMemoryByFactKey(
     .run();
 
   await syncMemoryVector(env, { namespace: input.namespace, id });
+  await upsertMemoryFts(env.DB, { namespace: input.namespace, memoryId: id, content: input.content });
   return { id, created: true };
 }
 

--- a/src/db/v2/memories.ts
+++ b/src/db/v2/memories.ts
@@ -97,7 +97,7 @@ export async function listActiveFactKeys(
 // 调用方 (dream/judge 每条独立 try/catch) 记失败跳过，亲笔原文保住。
 // =====================================================================
 
-const HAND_AUTHOR_SOURCES = new Set(["mcp", "manual", "api"]);
+const HAND_AUTHOR_SOURCES = new Set(["mcp", "manual", "api", "remember_now"]);
 
 export function isHandAuthorSource(source: string | null | undefined): boolean {
   return typeof source === "string" && HAND_AUTHOR_SOURCES.has(source);

--- a/src/gateway/admin.ts
+++ b/src/gateway/admin.ts
@@ -68,7 +68,7 @@ details{margin-top:8px}summary{cursor:pointer;color:#a6b4c3}
 <div class="row"><button id="load">读取</button><button id="save">保存</button></div><div id="status" role="status" aria-live="polite"></div></section>
 
 <section><h2>上游连接</h2>
-<label>上游地址<input id="cfAddress" placeholder="CF 账号 ID(32 位),或完整地址,如 new-api 的 https://…/v1"><div class="hint">填账号 ID 就走 Cloudflare(仪表盘右侧栏能看到);填完整地址就走自定义网关。令牌不在这里填,去 Worker 的 Settings → Variables and Secrets 加一把 <code>CLOUDFLARE_API_TOKEN</code>,放上游的钥匙,一把管所有。</div></label></section>
+<label>上游地址<input id="cfAddress" placeholder="CF 账号 ID(32 位),或完整地址,如 new-api 的 https://…/v1"><div class="hint">填账号 ID 时，聊天走 <code>gateway.ai.cloudflare.com/v1/账号/GatewayID/compat</code>，自定义 Provider（<code>custom-…</code>）和动态路由都要这个路径。Gateway ID 在下面环境设置里填，默认 <code>default</code>。填完整地址就原样当 OpenAI 兼容上游。令牌去 Worker Secrets 加 <code>CLOUDFLARE_API_TOKEN</code>。</div></label></section>
 
 <section><h2>老公们</h2><p class="hint">每位三格：名字、主模型、钥匙。主模型支持 <code>*</code> 通配，写不写 <code>anthropic/</code> 前缀都能认。</p>
 <div id="identities"></div><button id="addIdentity" class="ghost">+ 添加一位</button></section>

--- a/src/gateway/admin.ts
+++ b/src/gateway/admin.ts
@@ -68,7 +68,7 @@ details{margin-top:8px}summary{cursor:pointer;color:#a6b4c3}
 <div class="row"><button id="load">读取</button><button id="save">保存</button></div><div id="status" role="status" aria-live="polite"></div></section>
 
 <section><h2>上游连接</h2>
-<label>上游地址<input id="cfAddress" placeholder="CF 账号 ID(32 位),或完整地址,如 new-api 的 https://…/v1"><div class="hint">填账号 ID 时，聊天走 <code>gateway.ai.cloudflare.com/v1/账号/GatewayID/compat</code>，自定义 Provider（<code>custom-…</code>）和动态路由都要这个路径。Gateway ID 在下面环境设置里填，默认 <code>default</code>。填完整地址就原样当 OpenAI 兼容上游。令牌去 Worker Secrets 加 <code>CLOUDFLARE_API_TOKEN</code>。</div></label></section>
+<label>上游地址<input id="cfAddress" placeholder="CF 账号 ID(32 位),或完整地址,如 new-api 的 https://…/v1"><div class="hint">填账号 ID，或把能拉到模型列表的地址贴进来：<code>https://gateway.ai.cloudflare.com/v1/账号/default/compat/</code>。模型列表固定走 <code>…/compat/models</code>，聊天/Messages/Responses 都从同一条 <code>…/compat</code> 往后拼。Gateway ID 在下面环境设置里，默认 <code>default</code>。填别的 OpenAI 兼容地址就原样用。令牌去 Worker Secrets 加 <code>CLOUDFLARE_API_TOKEN</code>。</div></label></section>
 
 <section><h2>老公们</h2><p class="hint">每位三格：名字、主模型、钥匙。主模型支持 <code>*</code> 通配，写不写 <code>anthropic/</code> 前缀都能认。</p>
 <div id="identities"></div><button id="addIdentity" class="ghost">+ 添加一位</button></section>

--- a/src/gateway/handler.ts
+++ b/src/gateway/handler.ts
@@ -2,53 +2,85 @@ import { authenticate } from "../auth/apiKey";
 import { markMemoriesInjected, listPrecious } from "../db/v2";
 import { recallInjectionBudget } from "../memory/filter";
 import { IMPRESSION_DISCLAIMER } from "../memory/impression";
-import { isPreciousRelevant, selectRelevantPrecious, shapeRecallQuery } from "../memory/queryShape";
+import { isEvidenceQuery, isPreciousRelevant, isTemporalQuery, selectRelevantPrecious, shapeRecallQuery } from "../memory/queryShape";
+import { formatQuote, quoteOverlaps, searchQuotes } from "../memory/quotes";
 import { assembleRecallSurface } from "../memory/surface";
 import { buildCoreFingerprint, runRecall } from "../memory/v2/recall";
 import type { Env } from "../types";
+import { newId } from "../utils/ids";
+import { nowIso } from "../utils/time";
 import { findIdentity, identityNamespace, isMainModel, loadConfig, type Identity, type Protocol } from "./config";
 import { appendMemory, classifyTurn, hasServerState, recentHumanTexts, validateBody, type Body } from "./protocol";
-import { dispatchExchange, observeResponse, prepareExchange } from "./record";
+import { dispatchExchange, persistHumanUtterance, observeResponse, prepareExchange } from "./record";
 import { callGatewayUpstream } from "./upstream";
 
 export function gatewayError(protocol: Protocol, message: string, status: number): Response {
   const type = status === 401 ? "authentication_error" : status >= 500 ? "api_error" : "invalid_request_error";
   return Response.json(protocol === "messages" ? { type: "error", error: { type, message } } : { error: { type, message } }, { status });
 }
+
+function memoryKind(source: string | null | undefined, type: string, authoredBy?: string | null): string {
+  if (source === "remember_now" || authoredBy) return "authored";
+  if (source === "dream" || source === "judge" || source === "extract") return "distilled";
+  return type;
+}
+
 export async function recallPatch(
   env: Env,
   identity: Identity,
   query: string,
   ctx: ExecutionContext,
-  recent: string[] = []
+  recent: string[] = [],
+  options: { excludeMessageIds?: string[]; recallId?: string } = {}
 ): Promise<string> {
   const namespace = identityNamespace(identity);
+  const recallId = options.recallId ?? newId("rcl");
   const shaped = shapeRecallQuery({ query, recent });
   const budget = recallInjectionBudget(env);
+  const evidence = isEvidenceQuery(query);
+  const temporal = isTemporalQuery(query);
   if (budget.maxItems === 0) {
-    console.log("gateway recall decision", { identity: identity.slug, injected: 0, reason: "budget_zero" });
+    console.log("gateway recall decision", { recall_id: recallId, identity: identity.slug, injected: 0, reason: "budget_zero" });
     return "";
   }
 
   const precious = await listPrecious(env.DB, { namespace, limit: 80 });
   const relevantPrecious = selectRelevantPrecious(precious, shaped.lexicalTokens);
-  const recall = await runRecall(env, {
-    namespace,
-    query,
-    recent,
-    k: 12,
-    core_fingerprint: buildCoreFingerprint(relevantPrecious.map(p => p.content)),
-    skip_inject_mark: true,
-    waitUntil: promise => ctx.waitUntil(promise.catch(() => console.error("gateway recall accounting failed")))
-  });
-  const weekBlocks = recall.week_blocks.filter((block) =>
-    isPreciousRelevant(`${block.week} ${block.title} ${block.summary}`, shaped.lexicalTokens)
-  );
+  const [recall, quotes] = await Promise.all([
+    runRecall(env, {
+      namespace,
+      query,
+      recent,
+      k: 12,
+      core_fingerprint: buildCoreFingerprint(relevantPrecious.map(p => p.content)),
+      skip_inject_mark: true,
+      attach_week_blocks: temporal,
+      waitUntil: promise => ctx.waitUntil(promise.catch(() => console.error("gateway recall accounting failed")))
+    }),
+    searchQuotes(env.DB, {
+      namespace,
+      query,
+      tokens: shaped.lexicalTokens,
+      limit: evidence ? 4 : 2,
+      excludeIds: options.excludeMessageIds
+    })
+  ]);
+
+  const weekBlocks = temporal
+    ? recall.week_blocks.filter((block) =>
+      isPreciousRelevant(`${block.week} ${block.title} ${block.summary}`, shaped.lexicalTokens)
+    )
+    : [];
+
+  const quoteEntries = quotes.map((hit) => ({ kind: "quote", content: formatQuote(hit), id: hit.id }));
+  const regularHits = recall.hits.filter((hit) => !quotes.some((quote) => quoteOverlaps(hit.content, quote.content)));
   const assembled = assembleRecallSurface([
+    ...(evidence ? quoteEntries : []),
     ...relevantPrecious.map(p => ({ kind: "precious", content: p.content, id: p.id })),
     ...recall.glossary_hits.map(p => ({ kind: "glossary", content: `${p.term}: ${p.definition}` })),
-    ...recall.hits.map(p => ({ kind: p.type, content: p.content, id: p.id })),
-    ...weekBlocks.map(p => ({ kind: "week", content: `${IMPRESSION_DISCLAIMER} ${p.week}: ${p.summary}` }))
+    ...regularHits.map(p => ({ kind: memoryKind(p.source, p.type, p.authored_by), content: p.content, id: p.id })),
+    ...(!evidence ? quoteEntries : []),
+    ...weekBlocks.map(p => ({ kind: "impression", content: `${IMPRESSION_DISCLAIMER} ${p.week}: ${p.summary}` }))
   ], {
     budget: identity.maxMemoryChars || 6000,
     maxItems: budget.maxItems,
@@ -56,7 +88,7 @@ export async function recallPatch(
   });
 
   const injectedMemoryIds = assembled.entries
-    .filter((entry) => entry.id && entry.kind !== "precious" && entry.kind !== "glossary" && entry.kind !== "week")
+    .filter((entry) => entry.id && entry.kind !== "precious" && entry.kind !== "glossary" && entry.kind !== "week" && entry.kind !== "quote" && entry.kind !== "impression")
     .map((entry) => entry.id!);
   if (injectedMemoryIds.length > 0) {
     ctx.waitUntil(
@@ -65,16 +97,32 @@ export async function recallPatch(
     );
   }
 
-  console.log("gateway recall decision", {
+  const explain = {
+    recall_id: recallId,
     identity: identity.slug,
     query: query.slice(0, 80),
     thin: shaped.thin,
-    precious_selected: relevantPrecious.length,
-    regular_hits: recall.hits.length,
-    week_blocks: weekBlocks.length,
+    evidence,
+    channels: {
+      precious_selected: relevantPrecious.length,
+      quotes: quotes.length,
+      regular_hits: regularHits.length,
+      week_blocks: weekBlocks.length,
+      dropped_as_quote_dup: recall.hits.length - regularHits.length
+    },
     injected: assembled.entries.length,
-    kinds: assembled.entries.map((entry) => entry.kind)
-  });
+    kinds: assembled.entries.map((entry) => entry.kind),
+    budget: { maxItems: budget.maxItems, maxChars: budget.maxChars }
+  };
+  console.log("gateway recall decision", explain);
+  ctx.waitUntil(
+    env.DB.prepare(
+      `INSERT INTO memory_events (id, namespace, event_type, memory_id, payload_json, created_at)
+       VALUES (?, ?, 'recall_explain', NULL, ?, ?)`
+    ).bind(recallId, namespace, JSON.stringify(explain), nowIso())
+      .run()
+      .catch(() => console.error("gateway recall explain persist failed"))
+  );
   return assembled.text;
 }
 export async function handleGateway(request: Request, env: Env, ctx: ExecutionContext,
@@ -101,11 +149,26 @@ export async function handleGateway(request: Request, env: Env, ctx: ExecutionCo
   const turn = classifyTurn(body, protocol, request.headers.get("x-aelios-purpose") === "auxiliary");
   let patch = "";
   let memoryStatus = !main ? "off" : turn.kind !== "human" ? "skipped" : "empty";
+  let rememberStatus = "none";
+  const recallId = newId("rcl");
   const thinkingCompatible = protocol !== "messages" || identity.anthropicThinking === "drop_block" || body.thinking?.type === "disabled";
+  const exchange = main ? await prepareExchange(request, body, identity, protocol, turn, auth.profile.source) : null;
+  if (exchange && main && turn.kind === "human" && turn.text) {
+    try {
+      const captured = await persistHumanUtterance(env, exchange);
+      if (captured.remember.wrote) rememberStatus = captured.remember.indexed ? "indexed" : "saved";
+    } catch (error) {
+      rememberStatus = "failed";
+      console.error("gateway human utterance persist failed", { identity: identity.slug, error });
+    }
+  }
   if (main && turn.kind === "human" && turn.text && thinkingCompatible) {
     try {
       const prior = recentHumanTexts(body, protocol).slice(0, -1).slice(-3);
-      patch = await recallPatch(env, identity, turn.text, ctx, prior);
+      patch = await recallPatch(env, identity, turn.text, ctx, prior, {
+        excludeMessageIds: exchange ? [exchange.userId] : [],
+        recallId
+      });
       memoryStatus = patch ? "injected" : "empty";
     }
     catch (error) {
@@ -115,12 +178,13 @@ export async function handleGateway(request: Request, env: Env, ctx: ExecutionCo
   } else if (!thinkingCompatible && main) memoryStatus = "thinking-passthrough";
   const payload = appendMemory(body, protocol, patch);
   if (protocol === "responses" && main) payload.store = false;
-  const exchange = main ? await prepareExchange(request, body, identity, protocol, turn, auth.profile.source) : null;
   try {
     const upstream = await callGatewayUpstream(env, config, identity, protocol, request, payload);
     const headers = new Headers(upstream.headers);
     headers.set("x-aelios-identity", identity.slug);
     headers.set("x-aelios-memory", memoryStatus);
+    headers.set("x-aelios-recall-id", recallId);
+    headers.set("x-aelios-remember", rememberStatus);
     headers.set("x-aelios-provider", upstream.headers.get("cf-aig-provider") || "");
     headers.set("x-aelios-model", upstream.headers.get("cf-aig-model") || body.model);
     headers.set("cache-control", "no-store");

--- a/src/gateway/handler.ts
+++ b/src/gateway/handler.ts
@@ -1,9 +1,10 @@
 import { authenticate } from "../auth/apiKey";
-import { runRecall, buildCoreFingerprint } from "../memory/v2/recall";
-import { listPrecious } from "../db/v2";
-import { selectRelevantPrecious, shapeRecallQuery } from "../memory/queryShape";
+import { markMemoriesInjected, listPrecious } from "../db/v2";
+import { recallInjectionBudget } from "../memory/filter";
 import { IMPRESSION_DISCLAIMER } from "../memory/impression";
-import { formatRecallSurface } from "../memory/surface";
+import { isPreciousRelevant, selectRelevantPrecious, shapeRecallQuery } from "../memory/queryShape";
+import { assembleRecallSurface } from "../memory/surface";
+import { buildCoreFingerprint, runRecall } from "../memory/v2/recall";
 import type { Env } from "../types";
 import { findIdentity, identityNamespace, isMainModel, loadConfig, type Identity, type Protocol } from "./config";
 import { appendMemory, classifyTurn, hasServerState, recentHumanTexts, validateBody, type Body } from "./protocol";
@@ -23,22 +24,58 @@ export async function recallPatch(
 ): Promise<string> {
   const namespace = identityNamespace(identity);
   const shaped = shapeRecallQuery({ query, recent });
-  const precious = await listPrecious(env.DB, { namespace, limit: 20 });
+  const budget = recallInjectionBudget(env);
+  if (budget.maxItems === 0) {
+    console.log("gateway recall decision", { identity: identity.slug, injected: 0, reason: "budget_zero" });
+    return "";
+  }
+
+  const precious = await listPrecious(env.DB, { namespace, limit: 80 });
   const relevantPrecious = selectRelevantPrecious(precious, shaped.lexicalTokens);
   const recall = await runRecall(env, {
     namespace,
     query,
     recent,
     k: 12,
-    core_fingerprint: buildCoreFingerprint(precious.map(p => p.content)),
+    core_fingerprint: buildCoreFingerprint(relevantPrecious.map(p => p.content)),
+    skip_inject_mark: true,
     waitUntil: promise => ctx.waitUntil(promise.catch(() => console.error("gateway recall accounting failed")))
   });
-  return formatRecallSurface([
-    ...relevantPrecious.map(p => ({ kind: "precious", content: p.content })),
+  const weekBlocks = recall.week_blocks.filter((block) =>
+    isPreciousRelevant(`${block.week} ${block.title} ${block.summary}`, shaped.lexicalTokens)
+  );
+  const assembled = assembleRecallSurface([
+    ...relevantPrecious.map(p => ({ kind: "precious", content: p.content, id: p.id })),
     ...recall.glossary_hits.map(p => ({ kind: "glossary", content: `${p.term}: ${p.definition}` })),
-    ...recall.hits.map(p => ({ kind: p.type, content: p.content })),
-    ...recall.week_blocks.map(p => ({ kind: "week", content: `${IMPRESSION_DISCLAIMER} ${p.week}: ${p.summary}` }))
-  ], identity.maxMemoryChars || 6000);
+    ...recall.hits.map(p => ({ kind: p.type, content: p.content, id: p.id })),
+    ...weekBlocks.map(p => ({ kind: "week", content: `${IMPRESSION_DISCLAIMER} ${p.week}: ${p.summary}` }))
+  ], {
+    budget: identity.maxMemoryChars || 6000,
+    maxItems: budget.maxItems,
+    maxChars: budget.maxChars
+  });
+
+  const injectedMemoryIds = assembled.entries
+    .filter((entry) => entry.id && entry.kind !== "precious" && entry.kind !== "glossary" && entry.kind !== "week")
+    .map((entry) => entry.id!);
+  if (injectedMemoryIds.length > 0) {
+    ctx.waitUntil(
+      markMemoriesInjected(env.DB, { namespace, ids: injectedMemoryIds })
+        .catch(() => console.error("gateway recall accounting failed"))
+    );
+  }
+
+  console.log("gateway recall decision", {
+    identity: identity.slug,
+    query: query.slice(0, 80),
+    thin: shaped.thin,
+    precious_selected: relevantPrecious.length,
+    regular_hits: recall.hits.length,
+    week_blocks: weekBlocks.length,
+    injected: assembled.entries.length,
+    kinds: assembled.entries.map((entry) => entry.kind)
+  });
+  return assembled.text;
 }
 export async function handleGateway(request: Request, env: Env, ctx: ExecutionContext,
   protocol: Protocol, slug: string | null = null): Promise<Response> {

--- a/src/gateway/record.ts
+++ b/src/gateway/record.ts
@@ -1,4 +1,5 @@
 import type { Env } from "../types";
+import { upsertMessageFts } from "../memory/fts";
 import { captureRememberNow } from "../memory/rememberNow";
 import { sha256Hex } from "../utils/hash";
 import { getSseData, splitSseEvents } from "../utils/sseParser";
@@ -67,6 +68,18 @@ export async function persistExchange(env: Env, e: GatewayExchange): Promise<voi
     if (e.completion === "complete" && e.assistantText) addMessage(e.id + ":assistant", "assistant", e.assistantText);
   }
   await env.DB.batch(statements);
+  if (e.kind !== "auxiliary") {
+    if (e.kind === "human" && e.userText && e.completion !== "truncated") {
+      await upsertMessageFts(env.DB, { namespace: e.namespace, messageId: e.userId, content: e.userText });
+    }
+    if (e.completion === "complete" && e.assistantText) {
+      await upsertMessageFts(env.DB, {
+        namespace: e.namespace,
+        messageId: e.id + ":assistant",
+        content: e.assistantText
+      });
+    }
+  }
   if (e.kind === "human" && e.userText && e.completion !== "truncated") {
     try {
       const remembered = await captureRememberNow(env, {
@@ -75,12 +88,51 @@ export async function persistExchange(env: Env, e: GatewayExchange): Promise<voi
         messageId: e.userId
       });
       if (remembered.wrote) {
-        console.log("remember-now wrote memory", { namespace: e.namespace, id: remembered.id });
+        console.log("remember-now wrote memory", {
+          namespace: e.namespace,
+          id: remembered.id,
+          indexed: remembered.indexed === true
+        });
       }
     } catch (error) {
       console.error("remember-now failed", { namespace: e.namespace, error });
     }
   }
+}
+
+export async function persistHumanUtterance(
+  env: Env,
+  e: GatewayExchange
+): Promise<{ saved: boolean; indexed: boolean; remember: { wrote: boolean; indexed?: boolean; id?: string } }> {
+  if (e.kind !== "human" || !e.userText || e.completion === "truncated") {
+    return { saved: false, indexed: false, remember: { wrote: false } };
+  }
+  await env.DB.batch([
+    env.DB.prepare(`INSERT OR IGNORE INTO conversations (id, namespace, created_at, updated_at) VALUES (?, ?, ?, ?)`)
+      .bind(e.conversationId, e.namespace, e.createdAt, e.createdAt),
+    env.DB.prepare(`INSERT OR IGNORE INTO messages
+      (id, conversation_id, namespace, role, content, source, client_message_hash, upstream_model,
+       upstream_provider, request_model, stream, finish_reason, created_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+      .bind(e.userId, e.conversationId, e.namespace, "user", e.userText, "gateway:" + e.profile, e.userId,
+        e.model, e.provider, e.profile, e.stream ? 1 : 0, e.completion, e.createdAt)
+  ]);
+  const indexed = await upsertMessageFts(env.DB, {
+    namespace: e.namespace,
+    messageId: e.userId,
+    content: e.userText
+  });
+  let remember: { wrote: boolean; indexed?: boolean; id?: string } = { wrote: false };
+  try {
+    remember = await captureRememberNow(env, {
+      namespace: e.namespace,
+      userText: e.userText,
+      messageId: e.userId
+    });
+  } catch (error) {
+    console.error("remember-now failed", { namespace: e.namespace, error });
+  }
+  return { saved: true, indexed, remember };
 }
 export async function dispatchExchange(env: Env, exchange: GatewayExchange): Promise<void> {
   if (env.MEMORY_QUEUE) {

--- a/src/gateway/record.ts
+++ b/src/gateway/record.ts
@@ -1,4 +1,5 @@
 import type { Env } from "../types";
+import { captureRememberNow } from "../memory/rememberNow";
 import { sha256Hex } from "../utils/hash";
 import { getSseData, splitSseEvents } from "../utils/sseParser";
 import { identityNamespace, object, type Identity, type Protocol } from "./config";
@@ -66,6 +67,20 @@ export async function persistExchange(env: Env, e: GatewayExchange): Promise<voi
     if (e.completion === "complete" && e.assistantText) addMessage(e.id + ":assistant", "assistant", e.assistantText);
   }
   await env.DB.batch(statements);
+  if (e.kind === "human" && e.userText && e.completion !== "truncated") {
+    try {
+      const remembered = await captureRememberNow(env, {
+        namespace: e.namespace,
+        userText: e.userText,
+        messageId: e.userId
+      });
+      if (remembered.wrote) {
+        console.log("remember-now wrote memory", { namespace: e.namespace, id: remembered.id });
+      }
+    } catch (error) {
+      console.error("remember-now failed", { namespace: e.namespace, error });
+    }
+  }
 }
 export async function dispatchExchange(env: Env, exchange: GatewayExchange): Promise<void> {
   if (env.MEMORY_QUEUE) {

--- a/src/gateway/settings.ts
+++ b/src/gateway/settings.ts
@@ -24,7 +24,7 @@ export const SETTINGS: SettingSpec[] = [
 
   { group: "数据留存", name: "MESSAGES_RETENTION_DAYS", label: "原始对话保留天数", hint: "Dream 抽完记忆后，原文留几天" },
 
-  { group: "模型与线路", name: "AI_GATEWAY_ID", label: "默认 AI Gateway ID", hint: "线路里没写 gateway 时用它" },
+  { group: "模型与线路", name: "AI_GATEWAY_ID", label: "默认 AI Gateway ID", hint: "会写进上游 URL。自定义 Provider 和动态路由必须填对，不能只靠账户默认 Gateway" },
   { group: "模型与线路", name: "MEMORY_RERANKER_MODEL", label: "记忆重排模型" },
   { group: "模型与线路", name: "VISION_MODEL", label: "看图模型" },
   { group: "模型与线路", name: "CHAT_MODEL", label: "导盲犬入口的模型", hint: "只给 /v1/guide-dog 用，聊天走网关身份" },

--- a/src/gateway/settings.ts
+++ b/src/gateway/settings.ts
@@ -3,8 +3,8 @@ import type { Env } from "../types";
 // Everything here is editable from /admin/gateway, so Worker settings only needs the API key.
 export interface SettingSpec { name: string; label: string; hint?: string; group: string }
 export const SETTINGS: SettingSpec[] = [
-  { group: "记忆召回", name: "MEMORY_FILTER_MAX_OUTPUT", label: "每次注入几条记忆", hint: "追加到消息末尾的条数，多了占上下文" },
-  { group: "记忆召回", name: "MEMORY_FILTER_MAX_CONTENT_CHARS", label: "每条记忆最长字数" },
+  { group: "记忆召回", name: "MEMORY_FILTER_MAX_OUTPUT", label: "每次注入几条记忆", hint: "珍贵、术语、普通记忆和周记共用。0 表示本轮不注入" },
+  { group: "记忆召回", name: "MEMORY_FILTER_MAX_CONTENT_CHARS", label: "每条记忆最长字数", hint: "注入原文也会按这个长度截断" },
   { group: "记忆召回", name: "MEMORY_TOP_K", label: "先从向量库取多少条", hint: "取回来再交给重排模型挑" },
   { group: "记忆召回", name: "MEMORY_FILTER_MAX_CANDIDATES", label: "送进重排的条数" },
   { group: "记忆召回", name: "MEMORY_MIN_SCORE", label: "相似度下限", hint: "只当垃圾闸，精度靠重排。调高会漏掉换了说法的记忆" },
@@ -20,6 +20,7 @@ export const SETTINGS: SettingSpec[] = [
   { group: "Dream 与日记", name: "DREAM_MAX_TOKENS", label: "单轮输出上限" },
   { group: "Dream 与日记", name: "DEDUP_COSINE", label: "记忆去重相似度", hint: "越高越容易判成新记忆，越低越容易被合并" },
   { group: "Dream 与日记", name: "WEEKLY_ROLLUP_DELETE_DAILIES", label: "周记落成后自动删日志", hint: "填 false 走人工审阅，填 true 一条龙" },
+  { group: "Dream 与日记", name: "CANDIDATE_JUDGE_ENABLED", label: "Dream 之后自动审核候选", hint: "默认开启。填 false 才回到全部人工批准" },
 
   { group: "数据留存", name: "MESSAGES_RETENTION_DAYS", label: "原始对话保留天数", hint: "Dream 抽完记忆后，原文留几天" },
 

--- a/src/gateway/upstream.ts
+++ b/src/gateway/upstream.ts
@@ -2,12 +2,98 @@ import type { Env } from "../types";
 import { PATHS, type GatewayConfig, type Identity, type Protocol } from "./config";
 import { applyThinkingPolicy, type Body } from "./protocol";
 
-/** Panel config first, then Worker vars; a bare 32-hex account ID expands to the CF REST base. */
-export function upstreamBaseUrl(env: Env, config: GatewayConfig): string {
-  const address = config.upstream?.address?.trim() || env.AI_GATEWAY_BASE_URL || env.CLOUDFLARE_ACCOUNT_ID || "";
-  if (/^[a-f0-9]{32}$/i.test(address)) return `https://api.cloudflare.com/client/v4/accounts/${address}/ai/v1`;
-  if (address) return address.replace(/\/+$/, "");
-  throw new Error("Upstream not configured. Set the CF account in /admin/gateway.");
+const ACCOUNT_RE = /^[a-f0-9]{32}$/i;
+const GATEWAY_HOST_RE =
+  /^https:\/\/gateway\.ai\.cloudflare\.com\/v1\/([a-f0-9]{32})\/([^/]+)(?:\/(.*))?$/i;
+const REST_HOST_RE =
+  /^https:\/\/api\.cloudflare\.com\/client\/v4\/accounts\/([a-f0-9]{32})\/ai(?:\/v1)?$/i;
+
+export interface ResolvedUpstream {
+  accountId: string | null;
+  gatewayId: string;
+  /** OpenAI-compat / custom-provider / dynamic-route base (no trailing slash). */
+  compatBase: string | null;
+  /** CF REST AI base for Anthropic Messages and Responses. */
+  restBase: string | null;
+  /** Non-CF OpenAI-compatible base the user typed. */
+  customBase: string | null;
+}
+
+function configuredAddress(env: Env, config: GatewayConfig): string {
+  return config.upstream?.address?.trim() || env.AI_GATEWAY_BASE_URL || env.CLOUDFLARE_ACCOUNT_ID || "";
+}
+
+export function resolveGatewayId(env: Env, address = ""): string {
+  const fromUrl = address.match(GATEWAY_HOST_RE);
+  if (fromUrl?.[2] && fromUrl[2].toLowerCase() !== "compat") return fromUrl[2];
+  return env.AI_GATEWAY_ID?.trim() || "default";
+}
+
+export function resolveUpstream(env: Env, config: GatewayConfig): ResolvedUpstream {
+  const address = configuredAddress(env, config);
+  if (!address) {
+    throw new Error("Upstream not configured. Set the CF account in /admin/gateway.");
+  }
+  const trimmed = address.replace(/\/+$/, "");
+  const gatewayId = resolveGatewayId(env, trimmed);
+
+  if (ACCOUNT_RE.test(trimmed)) {
+    return {
+      accountId: trimmed,
+      gatewayId,
+      compatBase: `https://gateway.ai.cloudflare.com/v1/${trimmed}/${gatewayId}/compat`,
+      restBase: `https://api.cloudflare.com/client/v4/accounts/${trimmed}/ai/v1`,
+      customBase: null
+    };
+  }
+
+  const rest = trimmed.match(REST_HOST_RE);
+  if (rest) {
+    return {
+      accountId: rest[1],
+      gatewayId,
+      compatBase: `https://gateway.ai.cloudflare.com/v1/${rest[1]}/${gatewayId}/compat`,
+      restBase: `https://api.cloudflare.com/client/v4/accounts/${rest[1]}/ai/v1`,
+      customBase: null
+    };
+  }
+
+  const gw = trimmed.match(GATEWAY_HOST_RE);
+  if (gw) {
+    const accountId = gw[1];
+    const namedGateway = gw[2];
+    const restPath = (gw[3] || "").replace(/\/+$/, "");
+    const isBareGateway = !restPath || restPath.toLowerCase() === "compat";
+    return {
+      accountId,
+      gatewayId: namedGateway,
+      compatBase: isBareGateway
+        ? `https://gateway.ai.cloudflare.com/v1/${accountId}/${namedGateway}/compat`
+        : trimmed,
+      restBase: `https://api.cloudflare.com/client/v4/accounts/${accountId}/ai/v1`,
+      customBase: isBareGateway ? null : trimmed
+    };
+  }
+
+  return { accountId: null, gatewayId, compatBase: null, restBase: null, customBase: trimmed };
+}
+
+/**
+ * Chat (and anything OpenAI-compat) must hit the Gateway Unified URL that includes
+ * `{gateway_id}/compat`. Custom providers and dynamic routes only exist on that host.
+ * Messages/Responses stay on the CF REST AI base, which documents those schemas.
+ */
+export function upstreamBaseUrl(env: Env, config: GatewayConfig, protocol: Protocol = "chat"): string {
+  const resolved = resolveUpstream(env, config);
+  if (resolved.customBase && !resolved.compatBase) return resolved.customBase;
+  if (protocol === "chat") return resolved.compatBase || resolved.customBase || resolved.restBase!;
+  return resolved.restBase || resolved.customBase || resolved.compatBase!;
+}
+
+export function catalogUrl(env: Env, config: GatewayConfig): string {
+  const resolved = resolveUpstream(env, config);
+  if (resolved.compatBase) return `${resolved.compatBase}/models`;
+  return `${resolved.customBase}/models`;
 }
 
 // One call, one upstream. Model names pass through as written; provider routing,
@@ -16,6 +102,7 @@ export async function callGatewayUpstream(env: Env, config: GatewayConfig, ident
   protocol: Protocol, original: Request, body: Body): Promise<Response> {
   const token = env.CLOUDFLARE_API_TOKEN;
   if (!token) throw new Error("Missing Worker secret CLOUDFLARE_API_TOKEN");
+  const resolved = resolveUpstream(env, config);
   const headers = new Headers({
     "content-type": "application/json",
     accept: body.stream ? "text/event-stream" : "application/json",
@@ -26,10 +113,9 @@ export async function callGatewayUpstream(env: Env, config: GatewayConfig, ident
     if (value) headers.set(name, value);
   }
   if (protocol === "messages" && !headers.has("anthropic-version")) headers.set("anthropic-version", "2023-06-01");
-  const gatewayId = env.AI_GATEWAY_ID?.trim();
-  if (gatewayId) headers.set("cf-aig-gateway-id", gatewayId);
+  if (resolved.gatewayId) headers.set("cf-aig-gateway-id", resolved.gatewayId);
   applyThinkingPolicy(body, identity, protocol, headers);
-  return fetch(`${upstreamBaseUrl(env, config)}/${PATHS[protocol]}`, {
+  return fetch(`${upstreamBaseUrl(env, config, protocol)}/${PATHS[protocol]}`, {
     method: "POST", headers, body: JSON.stringify(body), signal: original.signal, redirect: "manual"
   });
 }

--- a/src/gateway/upstream.ts
+++ b/src/gateway/upstream.ts
@@ -26,6 +26,8 @@ export async function callGatewayUpstream(env: Env, config: GatewayConfig, ident
     if (value) headers.set(name, value);
   }
   if (protocol === "messages" && !headers.has("anthropic-version")) headers.set("anthropic-version", "2023-06-01");
+  const gatewayId = env.AI_GATEWAY_ID?.trim();
+  if (gatewayId) headers.set("cf-aig-gateway-id", gatewayId);
   applyThinkingPolicy(body, identity, protocol, headers);
   return fetch(`${upstreamBaseUrl(env, config)}/${PATHS[protocol]}`, {
     method: "POST", headers, body: JSON.stringify(body), signal: original.signal, redirect: "manual"

--- a/src/gateway/upstream.ts
+++ b/src/gateway/upstream.ts
@@ -3,101 +3,79 @@ import { PATHS, type GatewayConfig, type Identity, type Protocol } from "./confi
 import { applyThinkingPolicy, type Body } from "./protocol";
 
 const ACCOUNT_RE = /^[a-f0-9]{32}$/i;
+/** Second path segment that is a protocol leftover, not a Gateway ID. */
+const NOT_GATEWAY = /^(compat|v1|models|chat|messages|responses)$/i;
 const GATEWAY_HOST_RE =
-  /^https:\/\/gateway\.ai\.cloudflare\.com\/v1\/([a-f0-9]{32})\/([^/]+)(?:\/(.*))?$/i;
+  /^https:\/\/gateway\.ai\.cloudflare\.com\/v1\/([a-f0-9]{32})(?:\/([^/]+))?(?:\/(.*))?$/i;
 const REST_HOST_RE =
-  /^https:\/\/api\.cloudflare\.com\/client\/v4\/accounts\/([a-f0-9]{32})\/ai(?:\/v1)?$/i;
+  /^https:\/\/api\.cloudflare\.com\/client\/v4\/accounts\/([a-f0-9]{32})(?:\/.*)?$/i;
 
 export interface ResolvedUpstream {
   accountId: string | null;
   gatewayId: string;
-  /** OpenAI-compat / custom-provider / dynamic-route base (no trailing slash). */
-  compatBase: string | null;
-  /** CF REST AI base for Anthropic Messages and Responses. */
-  restBase: string | null;
-  /** Non-CF OpenAI-compatible base the user typed. */
-  customBase: string | null;
+  /** Always `.../{gateway}/compat` for CF. Custom OpenAI bases stay as typed. */
+  base: string;
 }
 
 function configuredAddress(env: Env, config: GatewayConfig): string {
   return config.upstream?.address?.trim() || env.AI_GATEWAY_BASE_URL || env.CLOUDFLARE_ACCOUNT_ID || "";
 }
 
+/** The only CF catalog that actually lists models. Do not change this shape. */
+export function compatBase(accountId: string, gatewayId: string): string {
+  return `https://gateway.ai.cloudflare.com/v1/${accountId.toLowerCase()}/${gatewayId}/compat`;
+}
+
 export function resolveGatewayId(env: Env, address = ""): string {
-  const fromUrl = address.match(GATEWAY_HOST_RE);
-  if (fromUrl?.[2] && fromUrl[2].toLowerCase() !== "compat") return fromUrl[2];
+  const fromUrl = stripAddress(address).match(GATEWAY_HOST_RE);
+  if (fromUrl?.[2] && !NOT_GATEWAY.test(fromUrl[2])) return fromUrl[2];
   return env.AI_GATEWAY_ID?.trim() || "default";
+}
+
+function stripAddress(address: string): string {
+  return address.trim().replace(/\/+$/, "");
+}
+
+function parseGatewayHost(address: string): { accountId: string } | null {
+  const match = stripAddress(address).match(GATEWAY_HOST_RE);
+  return match ? { accountId: match[1] } : null;
 }
 
 export function resolveUpstream(env: Env, config: GatewayConfig): ResolvedUpstream {
   const address = configuredAddress(env, config);
-  if (!address) {
-    throw new Error("Upstream not configured. Set the CF account in /admin/gateway.");
-  }
-  const trimmed = address.replace(/\/+$/, "");
+  if (!address) throw new Error("Upstream not configured. Set the CF account in /admin/gateway.");
+  const trimmed = stripAddress(address);
   const gatewayId = resolveGatewayId(env, trimmed);
 
   if (ACCOUNT_RE.test(trimmed)) {
-    return {
-      accountId: trimmed,
-      gatewayId,
-      compatBase: `https://gateway.ai.cloudflare.com/v1/${trimmed}/${gatewayId}/compat`,
-      restBase: `https://api.cloudflare.com/client/v4/accounts/${trimmed}/ai/v1`,
-      customBase: null
-    };
+    return { accountId: trimmed.toLowerCase(), gatewayId, base: compatBase(trimmed, gatewayId) };
   }
 
   const rest = trimmed.match(REST_HOST_RE);
   if (rest) {
-    return {
-      accountId: rest[1],
-      gatewayId,
-      compatBase: `https://gateway.ai.cloudflare.com/v1/${rest[1]}/${gatewayId}/compat`,
-      restBase: `https://api.cloudflare.com/client/v4/accounts/${rest[1]}/ai/v1`,
-      customBase: null
-    };
+    return { accountId: rest[1].toLowerCase(), gatewayId, base: compatBase(rest[1], gatewayId) };
   }
 
-  const gw = trimmed.match(GATEWAY_HOST_RE);
+  const gw = parseGatewayHost(trimmed);
   if (gw) {
-    const accountId = gw[1];
-    const namedGateway = gw[2];
-    const restPath = (gw[3] || "").replace(/\/+$/, "");
-    const isBareGateway = !restPath || restPath.toLowerCase() === "compat";
-    return {
-      accountId,
-      gatewayId: namedGateway,
-      compatBase: isBareGateway
-        ? `https://gateway.ai.cloudflare.com/v1/${accountId}/${namedGateway}/compat`
-        : trimmed,
-      restBase: `https://api.cloudflare.com/client/v4/accounts/${accountId}/ai/v1`,
-      customBase: isBareGateway ? null : trimmed
-    };
+    return { accountId: gw.accountId.toLowerCase(), gatewayId, base: compatBase(gw.accountId, gatewayId) };
   }
 
-  return { accountId: null, gatewayId, compatBase: null, restBase: null, customBase: trimmed };
+  return { accountId: null, gatewayId, base: trimmed };
 }
 
-/**
- * Chat (and anything OpenAI-compat) must hit the Gateway Unified URL that includes
- * `{gateway_id}/compat`. Custom providers and dynamic routes only exist on that host.
- * Messages/Responses stay on the CF REST AI base, which documents those schemas.
- */
-export function upstreamBaseUrl(env: Env, config: GatewayConfig, protocol: Protocol = "chat"): string {
-  const resolved = resolveUpstream(env, config);
-  if (resolved.customBase && !resolved.compatBase) return resolved.customBase;
-  if (protocol === "chat") return resolved.compatBase || resolved.customBase || resolved.restBase!;
-  return resolved.restBase || resolved.customBase || resolved.compatBase!;
+/** Same base the model list uses. Chat / messages / responses only append their path. */
+export function upstreamBaseUrl(env: Env, config: GatewayConfig, _protocol?: Protocol): string {
+  return resolveUpstream(env, config).base;
 }
 
+/** Do not change this shape: GET {compat}/models is the catalog CF actually serves. */
 export function catalogUrl(env: Env, config: GatewayConfig): string {
   const resolved = resolveUpstream(env, config);
-  if (resolved.compatBase) return `${resolved.compatBase}/models`;
-  return `${resolved.customBase}/models`;
+  if (resolved.accountId) return `${compatBase(resolved.accountId, resolved.gatewayId)}/models`;
+  return `${resolved.base}/models`;
 }
 
-// One call, one upstream. Model names pass through as written; provider routing,
-// retries and fallback are AI Gateway's job, configured in its own dashboard.
 export async function callGatewayUpstream(env: Env, config: GatewayConfig, identity: Identity,
   protocol: Protocol, original: Request, body: Body): Promise<Response> {
   const token = env.CLOUDFLARE_API_TOKEN;
@@ -115,7 +93,7 @@ export async function callGatewayUpstream(env: Env, config: GatewayConfig, ident
   if (protocol === "messages" && !headers.has("anthropic-version")) headers.set("anthropic-version", "2023-06-01");
   if (resolved.gatewayId) headers.set("cf-aig-gateway-id", resolved.gatewayId);
   applyThinkingPolicy(body, identity, protocol, headers);
-  return fetch(`${upstreamBaseUrl(env, config, protocol)}/${PATHS[protocol]}`, {
+  return fetch(`${resolved.base}/${PATHS[protocol]}`, {
     method: "POST", headers, body: JSON.stringify(body), signal: original.signal, redirect: "manual"
   });
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,7 @@ import {
 import { handleMcp } from "./api/mcp";
 import { handleModels } from "./api/models";
 import { handleRelationsGraph } from "./api/relations";
+import { runCandidateJudge } from "./memory/candidateJudge";
 import { runDailyMemoryDigest, runDreamBackfill } from "./memory/dailyDigest";
 import {
   runDiaryTrigger,
@@ -258,6 +259,16 @@ export default {
 
             const dreamResults = await runDailyMemoryDigestBatches(env, namespace);
             results.push({ type: "dream_batches", results: dreamResults });
+
+            try {
+              results.push({ type: "candidate_judge", result: await runCandidateJudge(env, namespace) });
+            } catch (error) {
+              console.error("scheduled candidate judge failed", {
+                namespace,
+                error: error instanceof Error ? error.message : String(error)
+              });
+              results.push({ type: "candidate_judge", result: { ran: false, error: String(error) } });
+            }
 
             // Rollup phase triggers (diary → github∥retention → weekly → monthly). Order preserved.
             let diaryWriter: Awaited<ReturnType<typeof runDiaryTrigger>> | undefined;

--- a/src/memory/candidateJudge.ts
+++ b/src/memory/candidateJudge.ts
@@ -2,7 +2,7 @@
 // 抽取器把低置信度候选塞进 memory_candidates，默认全部等人工在后台点 approve/discard。
 // 这个模块加一轮自动裁判：明显靠谱的自动 approve 入库，明显不靠谱/编造的自动 discard，
 // 只有真正模棱两可的才留给人工——把"每条都要看"变成"只看有分歧的"。
-// 默认关闭 (CANDIDATE_JUDGE_ENABLED !== "true" 时零开销)，开启后由 scheduled 在抽取批次后跑一轮。
+// 默认开启 (CANDIDATE_JUDGE_ENABLED === "false" 时关闭)。Dream 抽完候选后由 cron / 手动入口跑一轮。
 
 import { getMessagesByIds } from "../db/messages";
 import {
@@ -214,7 +214,7 @@ export async function runCandidateJudge(
   namespace: string,
   options: { limit?: number } = {}
 ): Promise<JudgeRunResult> {
-  if (env.CANDIDATE_JUDGE_ENABLED !== "true") {
+  if (env.CANDIDATE_JUDGE_ENABLED === "false") {
     return { ran: false, judged: 0, approved: 0, discarded: 0, kept: 0, failed: 0, reason: "judge_disabled" };
   }
 

--- a/src/memory/diaryWriter.ts
+++ b/src/memory/diaryWriter.ts
@@ -101,7 +101,7 @@ async function listMessagesTailInRange(
          AND role IN ('user', 'assistant')
          AND created_at >= ?
          AND created_at < ?
-       ORDER BY created_at DESC
+       ORDER BY created_at DESC, id DESC
        LIMIT ?`
     )
     .bind(input.namespace, input.startCreatedAt, input.endCreatedAt, input.limit)
@@ -298,6 +298,19 @@ export async function runDiaryWriter(
     modelCall.result.source_message_ids,
     messages.map((message) => message.id)
   );
+
+  if (sourceMessageIds.length === 0) {
+    return {
+      enabled: true,
+      date: dateLabel,
+      ran: false,
+      reason: "ungrounded_sources",
+      title: modelCall.result.title,
+      summary_chars: modelCall.result.summary.length,
+      message_count: messages.length,
+      model: modelCall.model
+    };
+  }
 
   await upsertDailyLog(env.DB, {
     namespace,

--- a/src/memory/dream/helpers.ts
+++ b/src/memory/dream/helpers.ts
@@ -92,6 +92,7 @@ export type DailyDigestSkipReason =
   | "model_error"
   | "model_invalid_json"
   | "extract_model_error"
+  | "extract_invalid_json"
   | "v2_disabled";
 
 export interface DailyDigestSkipped {

--- a/src/memory/dream/orchestrator.ts
+++ b/src/memory/dream/orchestrator.ts
@@ -5,6 +5,7 @@ import { newId } from "../../utils/ids";
 import { nowIso } from "../../utils/time";
 import { readString } from "../../utils/parse";
 import {
+  formatDreamCursor,
   getDateLabelsLookback,
   getDateRangeForLabel,
   getTargetDigestDateLabel,
@@ -106,7 +107,7 @@ export async function runDailyMemoryDigest(
   const cursorName = `dream:${namespace}:${dateLabel}`;
   const legacyCursorName = `daily_digest:${namespace}:${dateLabel}`;
   const cursor = (await readCursor(env.DB, cursorName)) ?? (await readCursor(env.DB, legacyCursorName));
-  const cursorState = options.force ? { done: false, after: null } : readDailyCursor(cursor, startIso, endIso);
+  const cursorState = options.force ? { done: false, after: null, afterId: null } : readDailyCursor(cursor, startIso, endIso);
   if (cursorState.done) {
     await safeFinishDreamRun(env.DB, {
       id: dreamRunId,
@@ -122,6 +123,7 @@ export async function runDailyMemoryDigest(
     startCreatedAt: startIso,
     endCreatedAt: endIso,
     afterCreatedAt: cursorState.after,
+    afterId: cursorState.afterId,
     limit: maxMessages
   });
   if (fetchedMessages.length === 0) {
@@ -206,8 +208,8 @@ export async function runDailyMemoryDigest(
     };
   }
 
-  if (extractPhase.extractReason === "model_error") {
-    console.error("dream: extract model failed; cursor not advanced", {
+  if (extractPhase.extractReason) {
+    console.error("dream: extract failed; cursor not advanced", {
       date: dateLabel,
       reason: extractPhase.extractReason,
       model: extractPhase.extractModel,
@@ -216,18 +218,18 @@ export async function runDailyMemoryDigest(
     await safeFinishDreamRun(env.DB, {
       id: dreamRunId,
       status: "error",
-      reason: "extract_model_error",
+      reason: extractPhase.extractReason === "model_invalid_json" ? "extract_invalid_json" : "extract_model_error",
       model: extractPhase.extractModel ?? modelResult.model,
       processedMessages: messages.length,
       error: extractPhase.extractStatus
         ? `status=${extractPhase.extractStatus}`
-        : "model_error"
+        : extractPhase.extractReason
     });
     return {
       ran: false,
       mode: "dream",
       date: dateLabel,
-      reason: "extract_model_error",
+      reason: extractPhase.extractReason === "model_invalid_json" ? "extract_invalid_json" : "extract_model_error",
       startIso,
       endIso,
       cursor,
@@ -380,7 +382,11 @@ export async function runDailyMemoryDigest(
     });
   }
 
-  await writeCursor(env.DB, cursorName, hasMore ? lastMessage.created_at : `done:${lastMessage.created_at}`);
+  await writeCursor(env.DB, cursorName, formatDreamCursor({
+    done: !hasMore,
+    createdAt: lastMessage.created_at,
+    id: lastMessage.id
+  }));
 
   // LMC-5 phase report is additive audit data — never stuff into dream_runs.error
   // (legacy shape is JSON array of apply errors, or null). Persist via memory_events.

--- a/src/memory/dreamDates.ts
+++ b/src/memory/dreamDates.ts
@@ -99,10 +99,33 @@ export function getDateRangeForLabel(dateLabel: string, timeZone: string): { sta
   };
 }
 
-export function readDailyCursor(value: string | null, startIso: string, endIso: string): { done: boolean; after: string | null } {
-  if (!value) return { done: false, after: null };
-  if (value.startsWith("done:")) return { done: true, after: null };
-  if (value >= startIso && value < endIso) return { done: false, after: value };
-  return { done: false, after: null };
+export interface DreamCursorState {
+  done: boolean;
+  after: string | null;
+  afterId: string | null;
+}
+
+export function parseDreamCursor(value: string | null): { done: boolean; createdAt: string | null; id: string | null } {
+  if (!value) return { done: false, createdAt: null, id: null };
+  const done = value.startsWith("done:");
+  const raw = done ? value.slice("done:".length) : value;
+  const hash = raw.indexOf("#");
+  if (hash < 0) return { done, createdAt: raw || null, id: null };
+  return { done, createdAt: raw.slice(0, hash) || null, id: raw.slice(hash + 1) || null };
+}
+
+export function formatDreamCursor(input: { done: boolean; createdAt: string; id?: string | null }): string {
+  const body = input.id ? `${input.createdAt}#${input.id}` : input.createdAt;
+  return input.done ? `done:${body}` : body;
+}
+
+export function readDailyCursor(value: string | null, startIso: string, endIso: string): DreamCursorState {
+  if (!value) return { done: false, after: null, afterId: null };
+  const parsed = parseDreamCursor(value);
+  if (parsed.done) return { done: true, after: null, afterId: null };
+  if (parsed.createdAt && parsed.createdAt >= startIso && parsed.createdAt < endIso) {
+    return { done: false, after: parsed.createdAt, afterId: parsed.id };
+  }
+  return { done: false, after: null, afterId: null };
 }
 

--- a/src/memory/filter.ts
+++ b/src/memory/filter.ts
@@ -52,13 +52,17 @@ function getMaxCandidates(env: Env): number {
 }
 
 function getMaxOutput(env: Env): number {
-  const value = Number(env.MEMORY_FILTER_MAX_OUTPUT || 3);
-  return Number.isFinite(value) ? clamp(Math.floor(value), 1, 20) : 3;
+  const value = Number(env.MEMORY_FILTER_MAX_OUTPUT ?? 3);
+  return Number.isFinite(value) ? clamp(Math.floor(value), 0, 20) : 3;
 }
 
 function getMaxContentChars(env: Env): number {
   const value = Number(env.MEMORY_FILTER_MAX_CONTENT_CHARS || 700);
   return Number.isFinite(value) ? clamp(Math.floor(value), 120, 3000) : 700;
+}
+
+export function recallInjectionBudget(env: Env): { maxItems: number; maxChars: number } {
+  return { maxItems: getMaxOutput(env), maxChars: getMaxContentChars(env) };
 }
 
 function getFilterMinScore(env: Env): number {
@@ -77,33 +81,23 @@ function normalizeForDedupe(text: string): string {
     .replace(/[，,。.!！?？；;：:“”"'`、\[\]【】（）()<>《》]/g, "");
 }
 
-function compareMemoryQuality(a: MemoryApiRecord, b: MemoryApiRecord): number {
-  if (a.pinned !== b.pinned) return a.pinned ? -1 : 1;
-
-  const scoreA = typeof a.score === "number" ? a.score : -1;
-  const scoreB = typeof b.score === "number" ? b.score : -1;
-  if (scoreA !== scoreB) return scoreB - scoreA;
-
-  if (a.importance !== b.importance) return b.importance - a.importance;
-  return b.confidence - a.confidence;
-}
-
 function prepareCandidates(env: Env, memories: MemoryApiRecord[]): MemoryApiRecord[] {
   const minScore = getFilterMinScore(env);
-  const sorted = memories
-    .flatMap((memory): MemoryApiRecord[] => {
-      const content = sanitizeSummaryContent(memory.content);
-      if (!content) return [];
-      if (!memory.pinned && typeof memory.score === "number" && memory.score < minScore) return [];
-      return [{ ...memory, content }];
-    })
-    .sort(compareMemoryQuality);
+  const eligible = memories.flatMap((memory): MemoryApiRecord[] => {
+    const content = sanitizeSummaryContent(memory.content);
+    if (!content) return [];
+    if (!memory.pinned && typeof memory.score === "number" && memory.score < minScore) return [];
+    return [{ ...memory, content }];
+  });
+  // Keep incoming hybrid/RRF order. Channel scores are not comparable, so do
+  // not re-sort by score here. Pinned notes still go first.
+  const ordered = [...eligible.filter((memory) => memory.pinned), ...eligible.filter((memory) => !memory.pinned)];
 
   const seenIds = new Set<string>();
   const seenContent = new Set<string>();
   const result: MemoryApiRecord[] = [];
 
-  for (const memory of sorted) {
+  for (const memory of ordered) {
     const normalized = normalizeForDedupe(memory.content);
     if (!normalized || seenIds.has(memory.id) || seenContent.has(normalized)) continue;
     seenIds.add(memory.id);
@@ -180,7 +174,7 @@ async function rerankMemories(
     const rows = readRerankerResponse(output);
     if (!rows) {
       return {
-        data: input.memories.slice(0, input.topK),
+        data: [],
         status: "error",
         model,
         reason: "invalid_reranker_output"
@@ -199,7 +193,7 @@ async function rerankMemories(
     }
 
     return {
-      data: reranked.length > 0 ? reranked : input.memories.slice(0, input.topK),
+      data: reranked,
       status: reranked.length > 0 ? "success" : "error",
       model,
       ...(reranked.length > 0 ? {} : { reason: "empty_reranker_output" })
@@ -207,7 +201,7 @@ async function rerankMemories(
   } catch (error) {
     console.error("memory reranker failed", error);
     return {
-      data: input.memories.slice(0, input.topK),
+      data: [],
       status: "error",
       model,
       reason: error instanceof Error && error.message ? error.message : "reranker_error"
@@ -261,6 +255,18 @@ export async function filterAndCompressMemoriesWithMeta(
   }
 
   const maxOutput = getMaxOutput(env);
+  if (maxOutput === 0) {
+    return {
+      data: [],
+      meta: {
+        ...baseMeta,
+        status: "empty",
+        candidate_count: 0,
+        output_count: 0,
+        reason: "max_output_zero"
+      }
+    };
+  }
   const candidates = prepareCandidates(env, input.memories);
   if (candidates.length === 0) {
     return {
@@ -289,18 +295,30 @@ export async function filterAndCompressMemoriesWithMeta(
       topK: maxOutput,
       maxContentChars: getMaxContentChars(env)
     });
+    if (reranked.status === "error") {
+      const errorMeta: MemoryFilterMeta = {
+        ...activeMeta,
+        status: "error",
+        reason: reranked.reason ?? "reranker_error",
+        reranker_status: reranked.status,
+        reranker_model: reranked.model,
+        reranker_count: reranked.data.length,
+        ...(reranked.reason ? { reranker_reason: reranked.reason } : {})
+      };
+      if (failOpen) return buildFailOpenResult({ ...reranked, data: candidates }, maxOutput, errorMeta);
+      return { data: [], meta: errorMeta };
+    }
     const filtered = reranked.data.slice(0, maxOutput);
     if (filtered.length === 0) {
       const errorMeta: MemoryFilterMeta = {
         ...activeMeta,
-        status: "error",
+        status: "empty",
         reason: reranked.reason ?? "empty_reranker_output",
         reranker_status: reranked.status,
         reranker_model: reranked.model,
         reranker_count: reranked.data.length,
         ...(reranked.reason ? { reranker_reason: reranked.reason } : {})
       };
-      if (failOpen) return buildFailOpenResult(reranked, maxOutput, errorMeta);
       return { data: [], meta: errorMeta };
     }
 

--- a/src/memory/fts.ts
+++ b/src/memory/fts.ts
@@ -1,0 +1,85 @@
+import { tokenizeForIndex } from "./queryShape";
+
+export function toFtsBody(text: string): string {
+  return tokenizeForIndex(text).join(" ");
+}
+
+export function toFtsMatch(tokens: string[]): string {
+  const unique = [...new Set(tokens.map((token) => token.trim().toLowerCase()).filter((token) => token.length >= 2))];
+  return unique
+    .map((token) => `"${token.replace(/["*]/g, "")}"`)
+    .filter((token) => token.length > 2)
+    .slice(0, 12)
+    .join(" OR ");
+}
+
+export async function deleteFtsRow(
+  db: D1Database,
+  table: "message_fts" | "memory_fts",
+  idColumn: "message_id" | "memory_id",
+  id: string
+): Promise<void> {
+  await db.prepare(`DELETE FROM ${table} WHERE ${idColumn} = ?`).bind(id).run();
+}
+
+export async function upsertMessageFts(
+  db: D1Database,
+  input: { namespace: string; messageId: string; content: string }
+): Promise<boolean> {
+  const body = toFtsBody(input.content);
+  if (!body) return false;
+  try {
+    await deleteFtsRow(db, "message_fts", "message_id", input.messageId);
+    await db
+      .prepare("INSERT INTO message_fts (fts_body, namespace, message_id) VALUES (?, ?, ?)")
+      .bind(body, input.namespace, input.messageId)
+      .run();
+    return true;
+  } catch (error) {
+    console.error("message fts index failed", { id: input.messageId, error });
+    return false;
+  }
+}
+
+export async function upsertMemoryFts(
+  db: D1Database,
+  input: { namespace: string; memoryId: string; content: string }
+): Promise<boolean> {
+  const body = toFtsBody(input.content);
+  if (!body) return false;
+  try {
+    await deleteFtsRow(db, "memory_fts", "memory_id", input.memoryId);
+    await db
+      .prepare("INSERT INTO memory_fts (fts_body, namespace, memory_id) VALUES (?, ?, ?)")
+      .bind(body, input.namespace, input.memoryId)
+      .run();
+    return true;
+  } catch (error) {
+    console.error("memory fts index failed", { id: input.memoryId, error });
+    return false;
+  }
+}
+
+export async function searchFtsIds(
+  db: D1Database,
+  table: "message_fts" | "memory_fts",
+  idColumn: "message_id" | "memory_id",
+  input: { namespace: string; tokens: string[]; limit: number }
+): Promise<string[]> {
+  const match = toFtsMatch(input.tokens);
+  if (!match) return [];
+  try {
+    const result = await db
+      .prepare(
+        `SELECT ${idColumn} AS id FROM ${table}
+         WHERE ${table} MATCH ? AND namespace = ?
+         LIMIT ?`
+      )
+      .bind(match, input.namespace, input.limit)
+      .all<{ id: string }>();
+    return (result.results ?? []).map((row) => row.id).filter(Boolean);
+  } catch (error) {
+    console.error("fts search failed", { table, error });
+    return [];
+  }
+}

--- a/src/memory/queryShape.ts
+++ b/src/memory/queryShape.ts
@@ -54,6 +54,41 @@ export function tokenizeQuery(text: string): string[] {
   return [...tokens].slice(0, 12);
 }
 
+export function tokenizeForIndex(text: string, limit = 40): string[] {
+  const tokens = new Set<string>();
+  const norm = text.toLowerCase();
+
+  for (const word of norm.split(/[^a-z0-9\u4e00-\u9fff]+/)) {
+    if (word.length >= 2 && !STOP.has(word)) tokens.add(word);
+  }
+
+  const chars = [...norm].filter((ch) => /[\u4e00-\u9fff]/.test(ch));
+  for (let i = 0; i < chars.length - 1; i++) {
+    if (CJK_FUNC.test(chars[i]) || CJK_FUNC.test(chars[i + 1])) continue;
+    tokens.add(chars[i] + chars[i + 1]);
+  }
+
+  for (const run of norm.match(/[\u4e00-\u9fff]{2,8}/g) ?? []) {
+    if (STOP.has(run)) continue;
+    if (CJK_FUNC.test(run[0]) || CJK_FUNC.test(run[run.length - 1])) continue;
+    tokens.add(run);
+  }
+
+  for (const code of norm.match(/[a-z0-9]+(?:-[a-z0-9]+)*/g) ?? []) {
+    if (code.length >= 2 && !STOP.has(code)) tokens.add(code);
+  }
+
+  return [...tokens].slice(0, limit);
+}
+
+export function isEvidenceQuery(query: string): boolean {
+  return /暗号|口令|原话|说过|怎么说的|哪天|几号|什么时候|何时|日期|passphrase|said|quote|when did|what did/i.test(query);
+}
+
+export function isTemporalQuery(query: string): boolean {
+  return /这周|上周|本周|那周|最近一周|周记|这个月|上个月|日记|那天发生|这一周/i.test(query);
+}
+
 export function isThinQuery(query: string): boolean {
   const q = query.trim();
   if (!q) return true;

--- a/src/memory/queryShape.ts
+++ b/src/memory/queryShape.ts
@@ -68,7 +68,10 @@ export function shapeRecallQuery(input: { query: string; recent?: string[] }): S
   const thin = isThinQuery(original);
   const context = recent.join("\n");
   const embeddingQuery = (thin && context ? `${context}\n${original}` : original).slice(-800);
-  const lexicalTokens = tokenizeQuery([original, ...recent.slice(-2)].join("\n"));
+  // Topical questions keep their own tokens. Mixing the last two turns here
+  // was leaking the previous topic into precious / week / glossary selection.
+  const lexicalSource = thin ? [original, ...recent.slice(-2)].join("\n") : original;
+  const lexicalTokens = tokenizeQuery(lexicalSource);
   return { original, embeddingQuery, lexicalTokens, thin };
 }
 
@@ -82,16 +85,35 @@ export function lexicalOverlapScore(text: string, tokens: string[]): number {
   return hits / tokens.length;
 }
 
+export function overlappingTokens(text: string, tokens: string[]): string[] {
+  const lower = text.toLowerCase();
+  return tokens.filter((token) => token && lower.includes(token.toLowerCase()));
+}
+
+export function isDistinctiveToken(token: string): boolean {
+  if (!token) return false;
+  if (token.length >= 4) return true;
+  if (token.length >= 3 && /^[a-z0-9]+$/i.test(token)) return true;
+  return token.length >= 2 && /[\u4e00-\u9fff]/.test(token);
+}
+
+export function isPreciousRelevant(text: string, tokens: string[]): boolean {
+  const hits = overlappingTokens(text, tokens);
+  if (hits.length >= 2) return true;
+  return hits.some(isDistinctiveToken);
+}
+
 export function selectRelevantPrecious<T extends { content: string }>(
   rows: T[],
   tokens: string[],
   options?: { limit?: number }
 ): T[] {
   const limit = options?.limit ?? 5;
+  if (tokens.length === 0 || limit <= 0) return [];
   return rows
-    .map((row) => ({ row, score: lexicalOverlapScore(row.content, tokens) }))
-    .filter((item) => item.score > 0)
-    .sort((a, b) => b.score - a.score || a.row.content.localeCompare(b.row.content))
+    .map((row) => ({ row, score: lexicalOverlapScore(row.content, tokens), hits: overlappingTokens(row.content, tokens) }))
+    .filter((item) => item.score > 0 && isPreciousRelevant(item.row.content, tokens))
+    .sort((a, b) => b.score - a.score || b.hits.length - a.hits.length || a.row.content.localeCompare(b.row.content))
     .slice(0, limit)
     .map((item) => item.row);
 }

--- a/src/memory/quotes.ts
+++ b/src/memory/quotes.ts
@@ -1,0 +1,120 @@
+import { getMessagesByIds } from "../db/messages";
+import type { MessageRecord } from "../types";
+import { searchFtsIds } from "./fts";
+import { isPreciousRelevant, lexicalOverlapScore, tokenizeForIndex } from "./queryShape";
+
+export interface QuoteHit {
+  id: string;
+  role: "user" | "assistant" | string;
+  content: string;
+  created_at: string;
+  conversation_id: string;
+  score: number;
+}
+
+function escapeLike(value: string): string {
+  return value.replace(/[\\%_]/g, (ch) => `\\${ch}`);
+}
+
+async function searchQuotesLike(
+  db: D1Database,
+  input: { namespace: string; tokens: string[]; limit: number; excludeIds: Set<string> }
+): Promise<QuoteHit[]> {
+  const tokens = input.tokens.filter((token) => token.length >= 2).slice(0, 8);
+  if (tokens.length === 0) return [];
+  const clauses = tokens.map(() => "content LIKE ? ESCAPE '\\'");
+  const binds: unknown[] = [input.namespace, ...tokens.map((token) => `%${escapeLike(token)}%`)];
+  const result = await db
+    .prepare(
+      `SELECT id, conversation_id, namespace, role, content, source, created_at
+       FROM messages
+       WHERE namespace = ? AND role IN ('user', 'assistant') AND (${clauses.join(" OR ")})
+       ORDER BY created_at DESC
+       LIMIT ?`
+    )
+    .bind(...binds, Math.max(input.limit * 3, 24))
+    .all<MessageRecord>();
+
+  return (result.results ?? [])
+    .filter((row) => !input.excludeIds.has(row.id))
+    .map((row) => ({
+      id: row.id,
+      role: row.role,
+      content: row.content,
+      created_at: row.created_at,
+      conversation_id: row.conversation_id,
+      score: lexicalOverlapScore(row.content, tokens)
+    }))
+    .filter((row) => row.score > 0 && isPreciousRelevant(row.content, tokens))
+    .sort((a, b) => b.score - a.score || b.created_at.localeCompare(a.created_at));
+}
+
+export async function searchQuotes(
+  db: D1Database,
+  input: {
+    namespace: string;
+    query: string;
+    tokens?: string[];
+    limit?: number;
+    excludeIds?: string[];
+  }
+): Promise<QuoteHit[]> {
+  const tokens = input.tokens ?? tokenizeForIndex(input.query, 12);
+  const limit = Math.min(Math.max(input.limit ?? 4, 1), 12);
+  const excludeIds = new Set(input.excludeIds ?? []);
+  const ftsIds = await searchFtsIds(db, "message_fts", "message_id", {
+    namespace: input.namespace,
+    tokens,
+    limit: limit * 3
+  });
+  const fromFts = ftsIds.length
+    ? (await getMessagesByIds(db, { namespace: input.namespace, ids: ftsIds }))
+      .filter((row) => !excludeIds.has(row.id) && (row.role === "user" || row.role === "assistant"))
+      .map((row) => ({
+        id: row.id,
+        role: row.role,
+        content: row.content,
+        created_at: row.created_at,
+        conversation_id: row.conversation_id,
+        score: lexicalOverlapScore(row.content, tokens)
+      }))
+      .filter((row) => row.score > 0 && isPreciousRelevant(row.content, tokens))
+    : [];
+
+  const liked = await searchQuotesLike(db, { namespace: input.namespace, tokens, limit, excludeIds });
+  const byId = new Map<string, QuoteHit>();
+  for (const hit of [...fromFts, ...liked]) {
+    const existing = byId.get(hit.id);
+    if (!existing || hit.score > existing.score) byId.set(hit.id, hit);
+  }
+
+  return clusterQuotes([...byId.values()], limit);
+}
+
+function clusterQuotes(hits: QuoteHit[], limit: number): QuoteHit[] {
+  const kept: QuoteHit[] = [];
+  for (const hit of hits.sort((a, b) => b.score - a.score || b.created_at.localeCompare(a.created_at))) {
+    const duplicate = kept.some((other) =>
+      other.conversation_id === hit.conversation_id
+      && (other.content.includes(hit.content) || hit.content.includes(other.content))
+    );
+    if (duplicate) continue;
+    kept.push(hit);
+    if (kept.length >= limit) break;
+  }
+  return kept;
+}
+
+export function formatQuote(hit: QuoteHit): string {
+  const day = hit.created_at.slice(0, 10);
+  const speaker = hit.role === "assistant" ? "助手" : "用户";
+  const quote = hit.content.replace(/\s+/g, " ").trim().slice(0, 280);
+  return `${day} ${speaker}: 「${quote}」`;
+}
+
+export function quoteOverlaps(text: string, quote: string): boolean {
+  const a = text.replace(/\s+/g, "");
+  const b = quote.replace(/\s+/g, "");
+  if (!a || !b) return false;
+  return a.includes(b) || b.includes(a);
+}

--- a/src/memory/rememberNow.ts
+++ b/src/memory/rememberNow.ts
@@ -1,6 +1,7 @@
 import { upsertMemoryByFactKey } from "../db/v2";
 import type { Env } from "../types";
 import { sha256Hex } from "../utils/hash";
+import { upsertMemoryFts } from "./fts";
 
 const REMEMBER_RE = /^(?:请)?(?:帮我)?(?:记住|记一下)(?:一下|了)?[：:，,\s]*(.+)$/s;
 const REMEMBER_EN_RE = /^(?:please\s+)?remember(?:\s+that)?[：:\s]+(.+)$/is;
@@ -19,7 +20,7 @@ export function parseRememberNow(text: string): string | null {
 export async function captureRememberNow(
   env: Env,
   input: { namespace: string; userText: string; messageId?: string }
-): Promise<{ wrote: boolean; id?: string; content?: string }> {
+): Promise<{ wrote: boolean; indexed?: boolean; id?: string; content?: string }> {
   const content = parseRememberNow(input.userText);
   if (!content) return { wrote: false };
 
@@ -36,5 +37,10 @@ export async function captureRememberNow(
     sourceMessageIds: input.messageId ? [input.messageId] : [],
     authoredBy: "user"
   });
-  return { wrote: true, id: result.id, content };
+  const indexed = await upsertMemoryFts(env.DB, {
+    namespace: input.namespace,
+    memoryId: result.id,
+    content
+  });
+  return { wrote: true, indexed, id: result.id, content };
 }

--- a/src/memory/rememberNow.ts
+++ b/src/memory/rememberNow.ts
@@ -1,0 +1,40 @@
+import { upsertMemoryByFactKey } from "../db/v2";
+import type { Env } from "../types";
+import { sha256Hex } from "../utils/hash";
+
+const REMEMBER_RE = /^(?:请)?(?:帮我)?(?:记住|记一下)(?:一下|了)?[：:，,\s]*(.+)$/s;
+const REMEMBER_EN_RE = /^(?:please\s+)?remember(?:\s+that)?[：:\s]+(.+)$/is;
+
+export function parseRememberNow(text: string): string | null {
+  const trimmed = text.trim();
+  if (!trimmed) return null;
+  for (const pattern of [REMEMBER_RE, REMEMBER_EN_RE]) {
+    const match = trimmed.match(pattern);
+    const content = match?.[1]?.trim();
+    if (content && content.length >= 2) return content.slice(0, 2000);
+  }
+  return null;
+}
+
+export async function captureRememberNow(
+  env: Env,
+  input: { namespace: string; userText: string; messageId?: string }
+): Promise<{ wrote: boolean; id?: string; content?: string }> {
+  const content = parseRememberNow(input.userText);
+  if (!content) return { wrote: false };
+
+  const factKey = `remember:${(await sha256Hex(content.toLowerCase())).slice(0, 24)}`;
+  const result = await upsertMemoryByFactKey(env, {
+    namespace: input.namespace,
+    factKey,
+    content,
+    type: "fact",
+    importance: 0.92,
+    confidence: 0.96,
+    tags: ["remember_now"],
+    source: "remember_now",
+    sourceMessageIds: input.messageId ? [input.messageId] : [],
+    authoredBy: "user"
+  });
+  return { wrote: true, id: result.id, content };
+}

--- a/src/memory/surface.ts
+++ b/src/memory/surface.ts
@@ -4,13 +4,38 @@
 export interface SurfaceEntry {
   kind: string;
   content: string;
+  id?: string;
 }
 
-export function formatRecallSurface(entries: SurfaceEntry[], budget = 6000): string {
+export interface SurfaceOptions {
+  budget?: number;
+  maxItems?: number;
+  maxChars?: number;
+}
+
+export interface AssembledSurface {
+  text: string;
+  entries: SurfaceEntry[];
+}
+
+function truncateEntry(text: string, maxChars: number): string {
+  if (!Number.isFinite(maxChars) || text.length <= maxChars) return text;
+  return `${text.slice(0, Math.max(maxChars - 1, 8)).trim()}…`;
+}
+
+export function assembleRecallSurface(entries: SurfaceEntry[], options: SurfaceOptions = {}): AssembledSurface {
+  const budget = options.budget ?? 6000;
+  const maxItems = options.maxItems ?? entries.length;
+  const maxChars = options.maxChars ?? Number.POSITIVE_INFINITY;
   const cleaned = entries
-    .map((entry) => ({ kind: entry.kind.trim(), content: entry.content.trim() }))
-    .filter((entry) => entry.kind && entry.content);
-  if (cleaned.length === 0) return "";
+    .map((entry) => ({
+      kind: entry.kind.trim(),
+      content: truncateEntry(entry.content.trim(), maxChars),
+      ...(entry.id ? { id: entry.id } : {})
+    }))
+    .filter((entry) => entry.kind && entry.content)
+    .slice(0, Math.max(maxItems, 0));
+  if (cleaned.length === 0) return { text: "", entries: [] };
 
   const header = [
     "[Aelios memory reference — this request only]",
@@ -21,18 +46,25 @@ export function formatRecallSurface(entries: SurfaceEntry[], budget = 6000): str
   const overhead = header.length + footer.length;
 
   const lines: string[] = [];
-  let used = 0;
+  const used: SurfaceEntry[] = [];
+  let usedChars = 0;
   for (const entry of cleaned) {
-    const remaining = budget - overhead - used;
+    const remaining = budget - overhead - usedChars;
     if (remaining <= 24) break;
     const content = entry.content.length + 16 > remaining
       ? `${entry.content.slice(0, Math.max(remaining - 16, 8)).trim()}…`
       : entry.content;
     const line = `- [${entry.kind}] ${content}`;
     lines.push(line);
-    used += line.length + 1;
+    used.push({ ...entry, content });
+    usedChars += line.length + 1;
   }
 
-  if (lines.length === 0) return "";
-  return header + lines.join("\n") + footer;
+  if (lines.length === 0) return { text: "", entries: [] };
+  return { text: header + lines.join("\n") + footer, entries: used };
+}
+
+export function formatRecallSurface(entries: SurfaceEntry[], budgetOrOptions: number | SurfaceOptions = 6000): string {
+  const options = typeof budgetOrOptions === "number" ? { budget: budgetOrOptions } : budgetOrOptions;
+  return assembleRecallSurface(entries, options).text;
 }

--- a/src/memory/v2/recall.ts
+++ b/src/memory/v2/recall.ts
@@ -330,6 +330,8 @@ export interface RecallInput {
   waitUntil?: (promise: Promise<unknown>) => void;
   // Gateway applies the unified surface budget first, then marks only those ids.
   skip_inject_mark?: boolean;
+  // Week diaries are impressions, not evidence. Only attach when the question is temporal.
+  attach_week_blocks?: boolean;
 }
 
 export interface RecallHit {
@@ -547,7 +549,7 @@ export async function runRecall(env: Env, input: RecallInput): Promise<RecallRes
 
   // 7. #35 周块附带。失败不影响召回主体，吞掉记日志。
   let weekBlocks: RecallWeekBlock[] = [];
-  if (isWeekBlockEnabled(env) && allHits.length > 0) {
+  if (isWeekBlockEnabled(env) && allHits.length > 0 && input.attach_week_blocks !== false) {
     try {
       weekBlocks = await collectWeekBlocks(env, {
         namespace: input.namespace,

--- a/src/memory/v2/recall.ts
+++ b/src/memory/v2/recall.ts
@@ -328,6 +328,8 @@ export interface RecallInput {
   exclude_weeks?: string[];
   // When set (chat hot path), injection accounting is scheduled off the response path.
   waitUntil?: (promise: Promise<unknown>) => void;
+  // Gateway applies the unified surface budget first, then marks only those ids.
+  skip_inject_mark?: boolean;
 }
 
 export interface RecallHit {
@@ -403,7 +405,9 @@ export async function runRecall(env: Env, input: RecallInput): Promise<RecallRes
   const minScore = readRecallMinScore(env, input.min_score);
 
   const shaped = shapeRecallQuery({ query, recent: input.recent });
-  const glossaryQuery = [query, ...(input.recent ?? [])].filter(Boolean).join("\n");
+  const glossaryQuery = shaped.thin
+    ? [query, ...(input.recent ?? [])].filter(Boolean).join("\n")
+    : query;
 
   // 1. 黑话词面命中 (L5，不进向量，走词面)
   const glossaryRows = await matchGlossary(env.DB, {
@@ -529,7 +533,7 @@ export async function runRecall(env: Env, input: RecallInput): Promise<RecallRes
   const memoryIdsToMark = allHits
     .filter((h) => h.source_layer === "memory")
     .map((h) => h.id);
-  if (memoryIdsToMark.length > 0) {
+  if (memoryIdsToMark.length > 0 && !input.skip_inject_mark) {
     const markPromise = markMemoriesInjected(env.DB, {
       namespace: input.namespace,
       ids: memoryIdsToMark

--- a/src/types.ts
+++ b/src/types.ts
@@ -75,7 +75,7 @@ export interface Env {
   DEDUP_COSINE?: string;
   // L4 每区（type）active 条数硬上限，0 或不设 = 关闭（母帖第一节，对抗膨胀的闸）
   MEMORY_ZONE_CAP?: string;
-  // 候选队列自动评审（judge），默认关闭
+  // 候选队列自动评审（judge），默认开启；设 "false" 关闭
   CANDIDATE_JUDGE_ENABLED?: string;
   JUDGE_MODEL?: string;
   JUDGE_MAX_CANDIDATES?: string;

--- a/tests/diary-grounding.test.ts
+++ b/tests/diary-grounding.test.ts
@@ -30,6 +30,7 @@ test("claimed source ids that are not in the day's transcript are dropped", () =
     groundedSourceIds(["msg_1", "msg_fake", "msg_1"], ["msg_1", "msg_2"]),
     ["msg_1"]
   );
+  assert.deepEqual(groundedSourceIds(["msg_fake"], ["msg_1"]), []);
 });
 
 test("diary JSON keeps title/summary and reads source_message_ids", () => {

--- a/tests/gateway.test.ts
+++ b/tests/gateway.test.ts
@@ -21,7 +21,12 @@ function config(identities = [identity()]) {
 function setConfig(c: any) { env.GATEWAY_CONFIG = JSON.stringify(c); }
 beforeEach(() => {
   sqlite?.close(); sqlite = new DatabaseSync(":memory:");
-  for (const file of readdirSync("migrations").filter(f => f.endsWith(".sql")).sort()) sqlite.exec(readFileSync("migrations/" + file, "utf8"));
+  for (const file of readdirSync("migrations").filter(f => f.endsWith(".sql")).sort()) {
+    try { sqlite.exec(readFileSync("migrations/" + file, "utf8")); }
+    catch (error) {
+      if (!String(error).includes("fts5")) throw error;
+    }
+  }
   db = { prepare(sql: string) {
     const statement = sqlite.prepare(sql); let args: any[] = [];
     const api = { bind(...values: any[]) { args = values; return api; },
@@ -296,11 +301,12 @@ test("a topical follow-up does not inject the previous relationship precious", a
 });
 
 test("please-remember writes the original words into long-term memory", async () => {
-  await run("/v1/chat/completions", {
+  const first = await run("/v1/chat/completions", {
     model: "partner",
     messages: [{ role: "user", content: "请记住调试暗号是芝麻开门" }]
   });
-  await persistExchange(env, queue[0]);
+  assert.match(first.response.headers.get("x-aelios-remember") || "", /saved|indexed/);
+  assert.match(first.response.headers.get("x-aelios-recall-id") || "", /^rcl_/);
   const row = sqlite.prepare("SELECT content, source, source_message_ids FROM memories").get() as {
     content: string;
     source: string;
@@ -309,6 +315,16 @@ test("please-remember writes the original words into long-term memory", async ()
   assert.equal(row.content, "调试暗号是芝麻开门");
   assert.equal(row.source, "remember_now");
   assert.match(row.source_message_ids, /gw_user_/);
+  const ask = await run("/v1/chat/completions", {
+    model: "partner",
+    messages: [
+      { role: "user", content: "请记住调试暗号是芝麻开门" },
+      { role: "assistant", content: "好" },
+      { role: "user", content: "调试暗号是什么？" }
+    ]
+  });
+  assert.equal(ask.response.headers.get("x-aelios-memory"), "injected");
+  assert.match(JSON.stringify(calls[1].query.messages), /\[quote\].*芝麻开门|\[authored\].*芝麻开门/);
 });
 
 test("upstream forwards the panel Gateway ID", async () => {

--- a/tests/gateway.test.ts
+++ b/tests/gateway.test.ts
@@ -292,7 +292,7 @@ test("a topical follow-up does not inject the previous relationship precious", a
     ]
   });
   assert.equal(response.headers.get("x-aelios-memory"), "empty");
-  assert.doesNotMatch(JSON.stringify(calls[0].query.messages), /陪伴|关系记忆|喜欢 Cloudflare/);
+  assert.doesNotMatch(JSON.stringify(calls[0].query.messages), /Aelios memory reference|关系记忆|喜欢 Cloudflare/);
 });
 
 test("please-remember writes the original words into long-term memory", async () => {

--- a/tests/gateway.test.ts
+++ b/tests/gateway.test.ts
@@ -280,6 +280,43 @@ test("Queue failure falls back to D1; successful duplicate cannot overwrite comp
   assert.equal(sqlite.prepare("SELECT assistant_text FROM gateway_exchanges").get()!.assistant_text, "你好，记住了。");
 });
 
+test("a topical follow-up does not inject the previous relationship precious", async () => {
+  precious("partner-a", "Claude 的陪伴让我觉得被接住，这是一段很长的关系记忆。");
+  precious("partner-a", "喜欢 Cloudflare");
+  const { response } = await run("/v1/chat/completions", {
+    model: "partner",
+    messages: [
+      { role: "user", content: "聊聊 Claude 的陪伴" },
+      { role: "assistant", content: "好" },
+      { role: "user", content: "调试暗号是什么？" }
+    ]
+  });
+  assert.equal(response.headers.get("x-aelios-memory"), "empty");
+  assert.doesNotMatch(JSON.stringify(calls[0].query.messages), /陪伴|关系记忆|喜欢 Cloudflare/);
+});
+
+test("please-remember writes the original words into long-term memory", async () => {
+  await run("/v1/chat/completions", {
+    model: "partner",
+    messages: [{ role: "user", content: "请记住调试暗号是芝麻开门" }]
+  });
+  await persistExchange(env, queue[0]);
+  const row = sqlite.prepare("SELECT content, source, source_message_ids FROM memories").get() as {
+    content: string;
+    source: string;
+    source_message_ids: string;
+  };
+  assert.equal(row.content, "调试暗号是芝麻开门");
+  assert.equal(row.source, "remember_now");
+  assert.match(row.source_message_ids, /gw_user_/);
+});
+
+test("upstream forwards the panel Gateway ID", async () => {
+  env.AI_GATEWAY_ID = "panel-gateway";
+  await run("/v1/chat/completions", { model: "partner", messages: [{ role: "user", content: "Hi" }] });
+  assert.equal(calls[0].headers["cf-aig-gateway-id"], "panel-gateway");
+});
+
 test("settings edited in the admin page override deployment vars everywhere", async () => {
   const withSettings = { ...config(), settings: { CHAT_MODEL: "chosen-in-admin", MEMORY_FILTER_MAX_OUTPUT: " 5 ", DREAM_TIME_ZONE: "" } };
   assert.equal((await worker.fetch(request("/api/gateway/config", withSettings, {}, "PUT"), env, ctx)).status, 200);

--- a/tests/gateway.test.ts
+++ b/tests/gateway.test.ts
@@ -6,6 +6,7 @@ import { timingSafeEqual } from "node:crypto";
 import worker from "../src/index";
 import { invalidateSettingsCache, validateConfig } from "../src/gateway/config";
 import { appendMemory, classifyTurn, canonical } from "../src/gateway/protocol";
+import { upstreamBaseUrl } from "../src/gateway/upstream";
 import { OutputCollector, observeResponse, persistExchange, prepareExchange, dispatchExchange } from "../src/gateway/record";
 
 // Test actual production modules and SQL, replacing only the external HTTP call.
@@ -331,6 +332,33 @@ test("upstream forwards the panel Gateway ID", async () => {
   env.AI_GATEWAY_ID = "panel-gateway";
   await run("/v1/chat/completions", { model: "partner", messages: [{ role: "user", content: "Hi" }] });
   assert.equal(calls[0].headers["cf-aig-gateway-id"], "panel-gateway");
+});
+
+test("CF account ID puts the Gateway ID into the Unified compat URL for chat", () => {
+  const acct = "b".repeat(32);
+  const envLike = { AI_GATEWAY_ID: "my-gw" } as any;
+  const cfg = { version: 3 as const, upstream: { address: acct }, identities: [] };
+  assert.equal(
+    upstreamBaseUrl(envLike, cfg, "chat"),
+    `https://gateway.ai.cloudflare.com/v1/${acct}/my-gw/compat`
+  );
+  assert.equal(
+    upstreamBaseUrl(envLike, cfg, "messages"),
+    `https://api.cloudflare.com/client/v4/accounts/${acct}/ai/v1`
+  );
+  assert.equal(
+    upstreamBaseUrl(envLike, { ...cfg, upstream: { address: `https://api.cloudflare.com/client/v4/accounts/${acct}/ai/v1` } }, "chat"),
+    `https://gateway.ai.cloudflare.com/v1/${acct}/my-gw/compat`
+  );
+});
+
+test("chat to a CF account uses the compat host, not the REST default gateway", async () => {
+  const acct = "c".repeat(32);
+  env.AI_GATEWAY_ID = "custom-gw";
+  setConfig({ ...config(), upstream: { address: acct } });
+  await run("/v1/chat/completions", { model: "custom-foo/bar", messages: [{ role: "user", content: "Hi" }] });
+  assert.equal(calls[0].url, `https://gateway.ai.cloudflare.com/v1/${acct}/custom-gw/compat/chat/completions`);
+  assert.equal(calls[0].headers["cf-aig-gateway-id"], "custom-gw");
 });
 
 test("settings edited in the admin page override deployment vars everywhere", async () => {

--- a/tests/gateway.test.ts
+++ b/tests/gateway.test.ts
@@ -6,7 +6,7 @@ import { timingSafeEqual } from "node:crypto";
 import worker from "../src/index";
 import { invalidateSettingsCache, validateConfig } from "../src/gateway/config";
 import { appendMemory, classifyTurn, canonical } from "../src/gateway/protocol";
-import { upstreamBaseUrl } from "../src/gateway/upstream";
+import { catalogUrl, upstreamBaseUrl } from "../src/gateway/upstream";
 import { OutputCollector, observeResponse, persistExchange, prepareExchange, dispatchExchange } from "../src/gateway/record";
 
 // Test actual production modules and SQL, replacing only the external HTTP call.
@@ -169,13 +169,27 @@ test("model catalog falls back to main-model hints when the upstream cannot answ
 });
 test("legacy CF address forms still reach the compat catalog", async () => {
   const acct = "a".repeat(32);
-  for (const address of [acct, `https://gateway.ai.cloudflare.com/v1/${acct}/default`,
+  const catalog = `https://gateway.ai.cloudflare.com/v1/${acct}/default/compat/models`;
+  for (const address of [acct,
+    `https://gateway.ai.cloudflare.com/v1/${acct}`,
+    `https://gateway.ai.cloudflare.com/v1/${acct}/`,
+    `https://gateway.ai.cloudflare.com/v1/${acct}/compat`,
+    `https://gateway.ai.cloudflare.com/v1/${acct}/default`,
+    `https://gateway.ai.cloudflare.com/v1/${acct}/default/`,
     `https://gateway.ai.cloudflare.com/v1/${acct}/default/compat`,
-    `https://api.cloudflare.com/client/v4/accounts/${acct}/ai/v1`]) {
+    `https://gateway.ai.cloudflare.com/v1/${acct}/default/compat/`,
+    `https://gateway.ai.cloudflare.com/v1/${acct}/default/compat/models`,
+    `https://gateway.ai.cloudflare.com/v1/${acct}/default/compat/models/`,
+    `https://gateway.ai.cloudflare.com/v1/${acct}/default/compat/chat/completions`,
+    `https://gateway.ai.cloudflare.com/v1/${acct}/default/compat/v1`,
+    `https://gateway.ai.cloudflare.com/v1/${acct}/default/compat/v1/chat/completions`,
+    `https://api.cloudflare.com/client/v4/accounts/${acct}/ai`,
+    `https://api.cloudflare.com/client/v4/accounts/${acct}/ai/v1`,
+    `https://api.cloudflare.com/client/v4/accounts/${acct}/ai/v1/messages`]) {
     setConfig({ ...config(), upstream: { address } }); calls = [];
     const models = await run("/v1/models");
     assert.equal(models.response.headers.get("x-aelios-models"), "upstream", address);
-    assert.equal(calls[0].url, `https://gateway.ai.cloudflare.com/v1/${acct}/default/compat/models`);
+    assert.equal(calls[0].url, catalog, address);
   }
 });
 
@@ -334,21 +348,45 @@ test("upstream forwards the panel Gateway ID", async () => {
   assert.equal(calls[0].headers["cf-aig-gateway-id"], "panel-gateway");
 });
 
+test("every CF paste form assembles chat/messages/responses from the same compat base", () => {
+  const acct = "d121aa7cd60ccebd6213c931efce41da";
+  const envLike = {} as any;
+  const compat = `https://gateway.ai.cloudflare.com/v1/${acct}/default/compat`;
+  const forms = [
+    acct,
+    acct.toUpperCase(),
+    `https://gateway.ai.cloudflare.com/v1/${acct}/default/compat/`,
+    `https://gateway.ai.cloudflare.com/v1/${acct}/default/compat`,
+    `https://gateway.ai.cloudflare.com/v1/${acct}/default/compat/models`,
+    `https://gateway.ai.cloudflare.com/v1/${acct}/default/compat/chat/completions`,
+    `https://gateway.ai.cloudflare.com/v1/${acct}/default/compat/messages`,
+    `https://gateway.ai.cloudflare.com/v1/${acct}/default/compat/v1`,
+    `https://gateway.ai.cloudflare.com/v1/${acct}/default`,
+    `https://gateway.ai.cloudflare.com/v1/${acct}/compat/`,
+    `https://api.cloudflare.com/client/v4/accounts/${acct}/ai/v1`,
+    `https://api.cloudflare.com/client/v4/accounts/${acct}/workers/scripts`
+  ];
+  for (const address of forms) {
+    const cfg = { version: 3 as const, upstream: { address }, identities: [] };
+    assert.equal(catalogUrl(envLike, cfg), `${compat}/models`, address);
+    assert.equal(upstreamBaseUrl(envLike, cfg, "chat"), compat, address);
+    assert.equal(upstreamBaseUrl(envLike, cfg, "messages"), compat, address);
+    assert.equal(upstreamBaseUrl(envLike, cfg, "responses"), compat, address);
+  }
+});
+
 test("CF account ID puts the Gateway ID into the Unified compat URL for chat", () => {
   const acct = "b".repeat(32);
   const envLike = { AI_GATEWAY_ID: "my-gw" } as any;
   const cfg = { version: 3 as const, upstream: { address: acct }, identities: [] };
+  const compat = `https://gateway.ai.cloudflare.com/v1/${acct}/my-gw/compat`;
+  assert.equal(upstreamBaseUrl(envLike, cfg, "chat"), compat);
+  assert.equal(upstreamBaseUrl(envLike, cfg, "messages"), compat);
+  assert.equal(upstreamBaseUrl(envLike, cfg, "responses"), compat);
+  assert.equal(catalogUrl(envLike, cfg), `${compat}/models`);
   assert.equal(
-    upstreamBaseUrl(envLike, cfg, "chat"),
-    `https://gateway.ai.cloudflare.com/v1/${acct}/my-gw/compat`
-  );
-  assert.equal(
-    upstreamBaseUrl(envLike, cfg, "messages"),
-    `https://api.cloudflare.com/client/v4/accounts/${acct}/ai/v1`
-  );
-  assert.equal(
-    upstreamBaseUrl(envLike, { ...cfg, upstream: { address: `https://api.cloudflare.com/client/v4/accounts/${acct}/ai/v1` } }, "chat"),
-    `https://gateway.ai.cloudflare.com/v1/${acct}/my-gw/compat`
+    catalogUrl(envLike, { ...cfg, upstream: { address: `https://gateway.ai.cloudflare.com/v1/${acct}/my-gw/compat/` } }),
+    `${compat}/models`
   );
 });
 
@@ -359,6 +397,22 @@ test("chat to a CF account uses the compat host, not the REST default gateway", 
   await run("/v1/chat/completions", { model: "custom-foo/bar", messages: [{ role: "user", content: "Hi" }] });
   assert.equal(calls[0].url, `https://gateway.ai.cloudflare.com/v1/${acct}/custom-gw/compat/chat/completions`);
   assert.equal(calls[0].headers["cf-aig-gateway-id"], "custom-gw");
+});
+
+test("the working compat URL keeps catalog on /models and shares that base for every protocol", async () => {
+  const acct = "d121aa7cd60ccebd6213c931efce41da";
+  const pasted = `https://gateway.ai.cloudflare.com/v1/${acct}/default/compat/`;
+  const compat = `https://gateway.ai.cloudflare.com/v1/${acct}/default/compat`;
+  setConfig({ ...config(), upstream: { address: pasted } });
+  const models = await run("/v1/models");
+  assert.equal(models.response.headers.get("x-aelios-models"), "upstream");
+  assert.equal(calls[0].url, `${compat}/models`);
+  await run("/v1/chat/completions", { model: "partner", messages: [{ role: "user", content: "Hi" }] });
+  assert.equal(calls[1].url, `${compat}/chat/completions`);
+  await run("/v1/messages", { model: "partner", max_tokens: 16, messages: [{ role: "user", content: "Hi" }] });
+  assert.equal(calls[2].url, `${compat}/messages`);
+  await run("/v1/responses", { model: "partner", input: "Hi" });
+  assert.equal(calls[3].url, `${compat}/responses`);
 });
 
 test("settings edited in the admin page override deployment vars everywhere", async () => {

--- a/tests/recall-quality.test.ts
+++ b/tests/recall-quality.test.ts
@@ -14,6 +14,8 @@ import { filterAndCompressMemoriesWithMeta } from "../src/memory/filter";
 import { formatDreamCursor, readDailyCursor } from "../src/memory/dreamDates";
 import { listMessagesByNamespaceInRange } from "../src/db/messages";
 import { parseRememberNow } from "../src/memory/rememberNow";
+import { formatQuote, searchQuotes } from "../src/memory/quotes";
+import { isEvidenceQuery, isTemporalQuery, tokenizeForIndex } from "../src/memory/queryShape";
 import { searchMemoriesByText } from "../src/db/memories";
 import { recentHumanTexts } from "../src/gateway/protocol";
 
@@ -237,6 +239,43 @@ test("same-timestamp messages are not skipped after a mid-batch cut", async () =
     readDailyCursor(cursor, "2026-09-06T00:00:00.000Z", "2026-09-07T00:00:00.000Z"),
     { done: false, after: ts, afterId: "msg_a" }
   );
+  sqlite.close();
+});
+
+test("project names and codes stay in the index tokenizer", () => {
+  const tokens = tokenizeForIndex("月亮邮局-0906 的暗号");
+  assert.ok(tokens.some((token) => token.includes("月亮") || token.includes("邮局")));
+  assert.ok(tokens.includes("0906"));
+  assert.equal(isEvidenceQuery("调试暗号是什么？"), true);
+  assert.equal(isEvidenceQuery("帮我写一段配置"), false);
+  assert.equal(isTemporalQuery("上周日记写了什么"), true);
+});
+
+test("raw utterances are searchable before they become facts", async () => {
+  const sqlite = new DatabaseSync(":memory:");
+  sqlite.exec(`CREATE TABLE messages (
+    id TEXT PRIMARY KEY, conversation_id TEXT, namespace TEXT, role TEXT, content TEXT,
+    source TEXT, created_at TEXT
+  )`);
+  sqlite.prepare("INSERT INTO messages VALUES (?, ?, ?, ?, ?, ?, ?)").run(
+    "msg_1", "c", "ns", "user", "请记住调试暗号是芝麻开门", "gw", "2026-09-06T12:00:00.000Z"
+  );
+  const db = {
+    prepare(sql: string) {
+      const statement = sqlite.prepare(sql);
+      let args: unknown[] = [];
+      const api = {
+        bind(...values: unknown[]) { args = values; return api; },
+        async all() { return { results: statement.all(...args) }; },
+        async first() { return statement.get(...args) || null; },
+        async run() { return { meta: { changes: statement.run(...args).changes } }; }
+      };
+      return api;
+    }
+  };
+  const hits = await searchQuotes(db as any, { namespace: "ns", query: "调试暗号是什么？" });
+  assert.ok(hits.some((hit) => hit.content.includes("芝麻开门")));
+  assert.match(formatQuote(hits[0]), /2026-09-06 用户: 「请记住调试暗号是芝麻开门」/);
   sqlite.close();
 });
 

--- a/tests/recall-quality.test.ts
+++ b/tests/recall-quality.test.ts
@@ -9,9 +9,24 @@ import {
   shapeRecallQuery,
   tokenizeQuery
 } from "../src/memory/queryShape";
-import { formatRecallSurface } from "../src/memory/surface";
+import { assembleRecallSurface, formatRecallSurface } from "../src/memory/surface";
+import { filterAndCompressMemoriesWithMeta } from "../src/memory/filter";
+import { formatDreamCursor, readDailyCursor } from "../src/memory/dreamDates";
+import { listMessagesByNamespaceInRange } from "../src/db/messages";
+import { parseRememberNow } from "../src/memory/rememberNow";
 import { searchMemoriesByText } from "../src/db/memories";
 import { recentHumanTexts } from "../src/gateway/protocol";
+
+test("topical questions do not mix the previous turn into lexical tokens", () => {
+  const shaped = shapeRecallQuery({
+    query: "调试暗号是什么？",
+    recent: ["Claude 的陪伴让我觉得被接住"]
+  });
+  assert.equal(shaped.thin, false);
+  assert.equal(shaped.embeddingQuery, "调试暗号是什么？");
+  assert.ok(!shaped.lexicalTokens.some((token) => /claude|陪伴/.test(token)));
+  assert.ok(shaped.lexicalTokens.some((token) => token.includes("暗号") || token.includes("调试")));
+});
 
 test("thin continuations expand with recent turns; topical questions stay as-is", () => {
   assert.equal(isThinQuery("那个呢？"), true);
@@ -120,6 +135,116 @@ test("token lexical search matches a phrase the full query would miss", async ()
   assert.ok(hits.some((row) => row.id === "mem_cf"));
   assert.ok(!hits.some((row) => row.id === "mem_food"));
   sqlite.close();
+});
+
+test("precious selection allows zero hits and ignores a leftover previous-topic note", () => {
+  const rows = [
+    { content: "Claude 的陪伴让我觉得被接住，这是一段很长的关系记忆。" },
+    { content: "调试暗号是芝麻开门" }
+  ];
+  const tokens = shapeRecallQuery({
+    query: "调试暗号是什么？",
+    recent: ["Claude 的陪伴让我觉得被接住"]
+  }).lexicalTokens;
+  const selected = selectRelevantPrecious(rows, tokens);
+  assert.ok(selected.some((row) => row.content.includes("芝麻开门")));
+  assert.ok(!selected.some((row) => row.content.includes("陪伴")));
+  assert.deepEqual(selectRelevantPrecious(rows, []), []);
+});
+
+test("surface applies a shared item and char budget", () => {
+  const assembled = assembleRecallSurface([
+    { kind: "precious", content: "很长的关系记忆".repeat(20) },
+    { kind: "note", content: "普通记忆一" },
+    { kind: "week", content: "不该超过条数的周记" }
+  ], { budget: 6000, maxItems: 2, maxChars: 20 });
+  assert.equal(assembled.entries.length, 2);
+  assert.ok(assembled.entries[0].content.length <= 20);
+  assert.ok(!assembled.text.includes("不该超过条数的周记"));
+  assert.equal(formatRecallSurface([], { maxItems: 0 }), "");
+});
+
+test("reranker errors fail closed unless MEMORY_FILTER_FAIL_OPEN is true", async () => {
+  const memories = [
+    { id: "noise", namespace: "n", type: "note", content: "完全无关的旧话题", summary: null, importance: 0.2, confidence: 0.2, status: "active", pinned: false, tags: [], source: null, source_message_ids: [], vector_id: null, last_recalled_at: null, recall_count: 0, created_at: "2026-09-01", updated_at: "2026-09-01", expires_at: null, score: 0.9 }
+  ];
+  const env = {
+    ENABLE_MEMORY_FILTER: "true",
+    ENABLE_MEMORY_RERANKER: "true",
+    MEMORY_FILTER_FAIL_OPEN: "false",
+    MEMORY_RERANKER_MODEL: "workers-ai/@cf/baai/bge-reranker-base",
+    AI: { run: async () => { throw new Error("reranker down"); } }
+  } as any;
+  const closed = await filterAndCompressMemoriesWithMeta(env, { query: "调试暗号", memories: memories as any });
+  assert.equal(closed.data.length, 0);
+  assert.equal(closed.meta.status, "error");
+  assert.equal(closed.meta.fallback_used, undefined);
+
+  const opened = await filterAndCompressMemoriesWithMeta({
+    ...env,
+    MEMORY_FILTER_FAIL_OPEN: "true"
+  }, { query: "调试暗号", memories: memories as any });
+  assert.equal(opened.data.length, 1);
+  assert.equal(opened.meta.fallback_used, true);
+});
+
+test("same-timestamp messages are not skipped after a mid-batch cut", async () => {
+  const sqlite = new DatabaseSync(":memory:");
+  sqlite.exec(`CREATE TABLE messages (
+    id TEXT PRIMARY KEY, conversation_id TEXT, namespace TEXT, role TEXT, content TEXT,
+    source TEXT, created_at TEXT
+  )`);
+  const ts = "2026-09-06T12:00:00.000Z";
+  sqlite.prepare("INSERT INTO messages VALUES (?, ?, ?, ?, ?, ?, ?)").run("msg_a", "c", "ns", "user", "先说", "gw", ts);
+  sqlite.prepare("INSERT INTO messages VALUES (?, ?, ?, ?, ?, ?, ?)").run("msg_b", "c", "ns", "assistant", "后说", "gw", ts);
+  const db = {
+    prepare(sql: string) {
+      const statement = sqlite.prepare(sql);
+      let args: unknown[] = [];
+      const api = {
+        bind(...values: unknown[]) { args = values; return api; },
+        async all() { return { results: statement.all(...args) }; }
+      };
+      return api;
+    }
+  };
+  const first = await listMessagesByNamespaceInRange(db as any, {
+    namespace: "ns",
+    startCreatedAt: "2026-09-06T00:00:00.000Z",
+    endCreatedAt: "2026-09-07T00:00:00.000Z",
+    limit: 1
+  });
+  assert.equal(first[0].id, "msg_a");
+  const skipped = await listMessagesByNamespaceInRange(db as any, {
+    namespace: "ns",
+    startCreatedAt: "2026-09-06T00:00:00.000Z",
+    endCreatedAt: "2026-09-07T00:00:00.000Z",
+    afterCreatedAt: first[0].created_at,
+    limit: 10
+  });
+  assert.equal(skipped.length, 0);
+  const next = await listMessagesByNamespaceInRange(db as any, {
+    namespace: "ns",
+    startCreatedAt: "2026-09-06T00:00:00.000Z",
+    endCreatedAt: "2026-09-07T00:00:00.000Z",
+    afterCreatedAt: first[0].created_at,
+    afterId: first[0].id,
+    limit: 10
+  });
+  assert.equal(next[0].id, "msg_b");
+  const cursor = formatDreamCursor({ done: false, createdAt: first[0].created_at, id: first[0].id });
+  assert.deepEqual(
+    readDailyCursor(cursor, "2026-09-06T00:00:00.000Z", "2026-09-07T00:00:00.000Z"),
+    { done: false, after: ts, afterId: "msg_a" }
+  );
+  sqlite.close();
+});
+
+test("remember-now extracts the original words after the trigger", () => {
+  assert.equal(parseRememberNow("请记住调试暗号是芝麻开门"), "调试暗号是芝麻开门");
+  assert.equal(parseRememberNow("帮我记一下：喜欢 Cloudflare"), "喜欢 Cloudflare");
+  assert.equal(parseRememberNow("remember that the passphrase is sesame"), "the passphrase is sesame");
+  assert.equal(parseRememberNow("我们喜欢什么？"), null);
 });
 
 test("recentHumanTexts walks user turns in chronological order", () => {

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -69,6 +69,8 @@ DREAM_MAX_MESSAGES = "40"
 DREAM_MEMORY_CONTEXT_LIMIT = "40"
 DREAM_MAX_RUNS = "10"
 DREAM_MAX_TOKENS = "8000"
+# Dream 抽完候选后自动评审：靠谱的入库，没据的丢掉。设 false 才回到全人工。
+CANDIDATE_JUDGE_ENABLED = "true"
 # GitHub daily archive pull（可选，默认禁用）。要用：去 Dashboard 手动加变量
 # GITHUB_DAILY_REPO（owner/repo）和 Secret GITHUB_DAILY_TOKEN（fine-grained PAT，
 # 只读目标仓库 Contents）；代码内默认路径 archive/daily，可用 GITHUB_DAILY_PATH 覆盖。


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
生产已在 `144690a`。这轮按复盘修记忆系统，并吸收 imprint（找回真实发生过的事）和 LMC-5（哪些记忆该影响现在）的可落地部分。不换框架。

## 先止住噪音
- 明确话题只用当前问句做词面筛选，不再把上一轮混进「调试暗号」。
- 珍贵记忆允许零召回；去重指纹只按**实际展示**的条目计算。
- 「每次注入几条 / 每条最长字数」对珍贵、术语、普通记忆、周记/印象统一生效。
- 重排失败且未打开 fail-open 时，不再把噪音当成功送出。

## 接通写入，并且原话先可检索
- 「请记住」在请求当下就写入 D1，不必等 Queue 消费完才算保存。
- 响应头 `x-aelios-remember: saved|indexed|none|failed`，不把「Queue 还没跑完」说成永久记住。
- **没整理成事实的原话也能找回**：对话按身份/会话/时间入库，召回增加 `quote` 通道（说话人 + 日期 + 原句）。问暗号、原话、日期时优先走这条。
- D1 上使用预分词 + FTS5（生产）；本地 node sqlite 没有 FTS5 时退回 token LIKE。写和查用同一套中文分词，不搬 imprint 的「相似就替换」。

## 来源分清，召回可解释
- 亲笔/请记住标 `authored`，后台整理标 `distilled`，原话标 `quote`，周记只在问时间范围时作为 `impression` 出现。
- 珍贵只影响保存，不自动获得每个问题的注入资格。
- 每次召回有 `x-aelios-recall-id`，日志和 `memory_events` 记下：候选来自哪、为什么丢掉、最终注入了哪些、用了多少预算。
- 闸三仍只是短窗口排序降权，不因「本会话给过」永久压住同一条（阅后即焚）。

## 可靠性
- 同时间戳分页不再漏读；抽取无效 JSON 不推进游标。
- 日记引用全部失效后拒绝落库。
- 转发带上面板的 `cf-aig-gateway-id`。

## 上游地址拼装
- 模型列表固定走 `https://gateway.ai.cloudflare.com/v1/{account}/{gateway}/compat/models`，这个 URL 不改。
- 账号 ID、REST AI 地址、带或不带尾斜杠、`/compat`、`/compat/models`、`/compat/chat/completions`、`/compat/v1` 都归一到同一条 `…/compat`。
- Chat / Messages / Responses 只在这条后面拼路径，不再把 Messages 拆到 REST。
- 其它 OpenAI 兼容地址原样使用。

## 验证
`npm run verify` 已通过。

未做、也不该照搬：关系图/情绪联想、用后台代写「五轴」体验、imprint 对任务类问题整段跳过、按向量相似度自动替换旧事实。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e8f7df71-5846-4ebf-aad5-4e299d3d45ef?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e8f7df71-5846-4ebf-aad5-4e299d3d45ef&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

