### PR TITLE
fix(memory): 自动审核、FTS 参数、问答顺序与原话质量

### DIFF
--- a/migrations/0015_message_seq.sql
+++ b/migrations/0015_message_seq.sql
@@ -1,0 +1,14 @@
+-- Turn-local sequence so same-timestamp user/assistant rows stay in ask-then-answer order.
+-- Hash IDs are unique only; they must not decide chronological order.
+ALTER TABLE messages ADD COLUMN seq INTEGER NOT NULL DEFAULT 0;
+
+UPDATE messages
+SET seq = CASE role
+  WHEN 'user' THEN 0
+  WHEN 'assistant' THEN 1
+  ELSE 2
+END
+WHERE seq = 0;
+
+CREATE INDEX IF NOT EXISTS idx_messages_namespace_created_seq
+ON messages(namespace, created_at, seq);

--- a/scripts/verify-vector-memory-write.mjs
+++ b/scripts/verify-vector-memory-write.mjs
@@ -195,7 +195,11 @@ assert.doesNotMatch(dbV2Source, /input\.newType \?\? "world_fact"/);
 assert.match(digestSource, /memories_to_add 默认给空数组/);
 assert.doesNotMatch(digestSource, /for \(const memory of digest\.memories_to_add \?\? \[\]\) \{\s+const factKey/s);
 assert.doesNotMatch(digestSource, /added \+= 0/);
-assert.match(candidateJudgeSource, /judgeResult\.score >= approveMin && judgeResult\.grounded && judgeResult\.durable/);
-assert.match(candidateJudgeSource, /judgeResult\.score <= discardMax \|\| !judgeResult\.grounded \|\| !judgeResult\.durable/);
+assert.match(candidateJudgeSource, /export function decideJudge/);
+assert.match(candidateJudgeSource, /source === "dream_delete"/);
+assert.match(candidateJudgeSource, /parseJudgeBoolean/);
+assert.match(candidateJudgeSource, /shouldDelete === true && result\.score >= thresholds\.approveMin/);
+assert.match(candidateJudgeSource, /normalized === "false"/);
+assert.doesNotMatch(candidateJudgeSource, /grounded: Boolean\(obj\.grounded\)/);
 
 console.log("verify-vector-memory-write: all checks passed");

--- a/src/db/memories.ts
+++ b/src/db/memories.ts
@@ -1,5 +1,5 @@
 import type { MemoryLifecycleRow, MemoryRecord } from "../types";
-import { searchFtsIds } from "../memory/fts";
+import { deleteFtsRow, searchFtsIds, upsertMemoryFts } from "../memory/fts";
 import { newId } from "../utils/ids";
 import { nowIso } from "../utils/time";
 
@@ -97,6 +97,7 @@ export async function createMemory(db: D1Database, input: CreateMemoryInput): Pr
     )
     .run();
 
+  await upsertMemoryFts(db, { namespace: record.namespace, memoryId: record.id, content: record.content });
   return record;
 }
 
@@ -300,7 +301,20 @@ export async function updateMemory(
     .bind(...binds, input.namespace, input.id)
     .run();
 
-  return getMemoryById(db, input);
+  const updated = await getMemoryById(db, input);
+  if (updated) {
+    const inactive = updated.status === "deleted" || updated.status === "archived" || updated.status === "expired";
+    if (inactive) {
+      await deleteFtsRow(db, "memory_fts", "memory_id", updated.id);
+    } else if (input.patch.content !== undefined || input.patch.summary !== undefined) {
+      await upsertMemoryFts(db, {
+        namespace: updated.namespace,
+        memoryId: updated.id,
+        content: `${updated.content}\n${updated.summary ?? ""}`
+      });
+    }
+  }
+  return updated;
 }
 
 export async function softDeleteMemory(
@@ -357,27 +371,34 @@ export async function searchMemoriesByText(
   }
   const binds: unknown[] = [input.namespace];
 
-  const clauses: string[] = [];
+  const likeClauses: string[] = [];
+  const likeBinds: unknown[] = [];
   if (query.length >= 2) {
     const like = `%${escapeLike(query)}%`;
-    clauses.push("(content LIKE ? ESCAPE '\\' OR summary LIKE ? ESCAPE '\\' OR tags LIKE ? ESCAPE '\\' OR type LIKE ? ESCAPE '\\')");
-    binds.push(like, like, like, like);
+    likeClauses.push("(content LIKE ? ESCAPE '\\' OR summary LIKE ? ESCAPE '\\' OR tags LIKE ? ESCAPE '\\' OR type LIKE ? ESCAPE '\\')");
+    likeBinds.push(like, like, like, like);
   }
   for (const token of tokens) {
     const like = `%${escapeLike(token)}%`;
-    clauses.push("(content LIKE ? ESCAPE '\\' OR summary LIKE ? ESCAPE '\\')");
-    binds.push(like, like);
+    likeClauses.push("(content LIKE ? ESCAPE '\\' OR summary LIKE ? ESCAPE '\\')");
+    likeBinds.push(like, like);
   }
   const ftsIds = tokens.length > 0
     ? await searchFtsIds(db, "memory_fts", "memory_id", { namespace: input.namespace, tokens, limit: input.limit })
     : [];
+  // SQL placeholders and bind values must stay in the same order.
+  // Previous code put `id IN (...)` first in SQL but appended IDs after LIKE binds.
   if (ftsIds.length > 0) {
     sql += ` AND (id IN (${ftsIds.map(() => "?").join(", ")})`;
     binds.push(...ftsIds);
-    if (clauses.length > 0) sql += ` OR (${clauses.join(" OR ")})`;
+    if (likeClauses.length > 0) {
+      sql += ` OR (${likeClauses.join(" OR ")})`;
+      binds.push(...likeBinds);
+    }
     sql += ")";
-  } else if (clauses.length > 0) {
-    sql += ` AND (${clauses.join(" OR ")})`;
+  } else if (likeClauses.length > 0) {
+    sql += ` AND (${likeClauses.join(" OR ")})`;
+    binds.push(...likeBinds);
   }
 
   if (input.types && input.types.length > 0) {

--- a/src/db/messages.ts
+++ b/src/db/messages.ts
@@ -1,7 +1,20 @@
+import { upsertMessageFts } from "../memory/fts";
 import type { MessageRecord, OpenAIChatMessage, TokenUsage } from "../types";
 import { sha256Hex } from "../utils/hash";
 import { newId } from "../utils/ids";
 import { nowIso } from "../utils/time";
+
+export const MESSAGE_ORDER_SQL =
+  "created_at ASC, seq ASC, CASE role WHEN 'user' THEN 0 WHEN 'assistant' THEN 1 ELSE 2 END ASC, id ASC";
+
+export const MESSAGE_ORDER_SQL_DESC =
+  "created_at DESC, seq DESC, CASE role WHEN 'user' THEN 0 WHEN 'assistant' THEN 1 ELSE 2 END DESC, id DESC";
+
+function roleSeq(role: string): number {
+  if (role === "user") return 0;
+  if (role === "assistant") return 1;
+  return 2;
+}
 
 function contentToText(content: OpenAIChatMessage["content"]): string {
   if (typeof content === "string") return content;
@@ -48,8 +61,8 @@ export async function saveUserMessages(
       .prepare(
         `INSERT OR IGNORE INTO messages (
           id, conversation_id, namespace, role, content, source, client_message_hash,
-          upstream_model, upstream_provider, request_model, stream, created_at
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+          upstream_model, upstream_provider, request_model, stream, created_at, seq
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
       )
       .bind(
         id,
@@ -63,7 +76,8 @@ export async function saveUserMessages(
         input.upstreamProvider,
         input.requestModel,
         input.stream ? 1 : 0,
-        nowIso()
+        nowIso(),
+        roleSeq("user")
       )
       .run();
 
@@ -77,6 +91,7 @@ export async function saveUserMessages(
     } else {
       ids.push(id);
     }
+    await upsertMessageFts(db, { namespace: input.namespace, messageId: ids[ids.length - 1], content });
   }
 
   return ids;
@@ -108,8 +123,8 @@ export async function saveAssistantMessage(
         id, conversation_id, namespace, role, content, source, upstream_model,
         upstream_provider, request_model, stream, finish_reason, token_input,
         token_output, cache_mode, cache_ttl, cache_hit, cache_read_tokens,
-        cache_creation_tokens, raw_usage_json, created_at
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+        cache_creation_tokens, raw_usage_json, created_at, seq
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
     )
     .bind(
       id,
@@ -131,10 +146,12 @@ export async function saveAssistantMessage(
       usage.cache_read_input_tokens ?? null,
       usage.cache_creation_input_tokens ?? null,
       JSON.stringify(usage),
-      nowIso()
+      nowIso(),
+      roleSeq("assistant")
     )
     .run();
 
+  await upsertMessageFts(db, { namespace: input.namespace, messageId: id, content: input.content });
   return id;
 }
 
@@ -147,10 +164,10 @@ export async function getMessagesByIds(
   const placeholders = input.ids.map(() => "?").join(", ");
   const result = await db
     .prepare(
-      `SELECT id, conversation_id, namespace, role, content, source, created_at
+      `SELECT id, conversation_id, namespace, role, content, source, created_at, seq
        FROM messages
        WHERE namespace = ? AND id IN (${placeholders})
-       ORDER BY created_at ASC, id ASC`
+       ORDER BY ${MESSAGE_ORDER_SQL}`
     )
     .bind(input.namespace, ...input.ids)
     .all<MessageRecord>();
@@ -190,7 +207,7 @@ export async function listMessagesByNamespace(
   afterCreatedAt: string | null,
   limit: number
 ): Promise<MessageRecord[]> {
-  let sql = `SELECT id, conversation_id, namespace, role, content, source, created_at
+  let sql = `SELECT id, conversation_id, namespace, role, content, source, created_at, seq
              FROM messages
              WHERE namespace = ? AND role IN ('user', 'assistant')`;
   const binds: unknown[] = [namespace];
@@ -200,7 +217,7 @@ export async function listMessagesByNamespace(
     binds.push(afterCreatedAt);
   }
 
-  sql += ` ORDER BY created_at ASC, id ASC LIMIT ?`;
+  sql += ` ORDER BY ${MESSAGE_ORDER_SQL} LIMIT ?`;
   binds.push(limit);
 
   const result = await db.prepare(sql).bind(...binds).all<MessageRecord>();
@@ -215,8 +232,13 @@ function appendAfterCursor(
 ): string {
   if (!afterCreatedAt) return sql;
   if (afterId) {
-    binds.push(afterCreatedAt, afterCreatedAt, afterId);
-    return `${sql} AND (created_at > ? OR (created_at = ? AND id > ?))`;
+    // Look up seq from the cursor row so hash IDs never decide order.
+    binds.push(afterCreatedAt, afterCreatedAt, afterId, afterCreatedAt, afterId, afterId);
+    return `${sql} AND (
+      created_at > ?
+      OR (created_at = ? AND seq > COALESCE((SELECT seq FROM messages WHERE id = ?), 0))
+      OR (created_at = ? AND seq = COALESCE((SELECT seq FROM messages WHERE id = ?), 0) AND id > ?)
+    )`;
   }
   binds.push(afterCreatedAt);
   return `${sql} AND created_at > ?`;
@@ -233,7 +255,7 @@ export async function listMessagesByNamespaceInRange(
     limit: number;
   }
 ): Promise<MessageRecord[]> {
-  let sql = `SELECT id, conversation_id, namespace, role, content, source, created_at
+  let sql = `SELECT id, conversation_id, namespace, role, content, source, created_at, seq
              FROM messages
              WHERE namespace = ?
                AND role IN ('user', 'assistant')
@@ -241,7 +263,7 @@ export async function listMessagesByNamespaceInRange(
                AND created_at < ?`;
   const binds: unknown[] = [input.namespace, input.startCreatedAt, input.endCreatedAt];
   sql = appendAfterCursor(sql, binds, input.afterCreatedAt, input.afterId);
-  sql += ` ORDER BY created_at ASC, id ASC LIMIT ?`;
+  sql += ` ORDER BY ${MESSAGE_ORDER_SQL} LIMIT ?`;
   binds.push(input.limit);
 
   const result = await db.prepare(sql).bind(...binds).all<MessageRecord>();
@@ -258,6 +280,7 @@ export async function saveIngestMessages(
   }
 ): Promise<string[]> {
   const ids: string[] = [];
+  let seq = 0;
 
   for (const message of input.messages) {
     const content = contentToText(message.content);
@@ -269,8 +292,8 @@ export async function saveIngestMessages(
     await db
       .prepare(
         `INSERT INTO messages (
-          id, conversation_id, namespace, role, content, source, stream, created_at
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+          id, conversation_id, namespace, role, content, source, stream, created_at, seq
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
       )
       .bind(
         id,
@@ -280,9 +303,12 @@ export async function saveIngestMessages(
         content,
         input.source,
         0,
-        nowIso()
+        nowIso(),
+        seq
       )
       .run();
+    await upsertMessageFts(db, { namespace: input.namespace, messageId: id, content });
+    seq += 1;
   }
 
   return ids;

--- a/src/db/retention.ts
+++ b/src/db/retention.ts
@@ -19,6 +19,19 @@ export async function deleteOldMessages(
   namespace: string,
   cutoff: string
 ): Promise<number> {
+  try {
+    await db
+      .prepare(
+        `DELETE FROM message_fts
+         WHERE message_id IN (
+           SELECT id FROM messages WHERE namespace = ? AND created_at < ?
+         )`
+      )
+      .bind(namespace, cutoff)
+      .run();
+  } catch (error) {
+    console.error("retention: message fts cleanup failed", error);
+  }
   const result = await db
     .prepare("DELETE FROM messages WHERE namespace = ? AND created_at < ?")
     .bind(namespace, cutoff)
@@ -166,6 +179,14 @@ async function hardDeleteMemoriesBatch(
 ): Promise<number> {
   if (ids.length === 0) return 0;
   const placeholders = ids.map(() => "?").join(", ");
+  try {
+    await db
+      .prepare(`DELETE FROM memory_fts WHERE memory_id IN (${placeholders})`)
+      .bind(...ids)
+      .run();
+  } catch (error) {
+    console.error("retention: memory fts hard-delete cleanup failed", error);
+  }
   const result = await db
     .prepare(
       `DELETE FROM memories WHERE namespace = ? AND id IN (${placeholders})`

--- a/src/db/v2/memories.ts
+++ b/src/db/v2/memories.ts
@@ -1,5 +1,5 @@
 import { upsertMemoryEmbedding } from "../../memory/embedding";
-import { upsertMemoryFts } from "../../memory/fts";
+import { deleteFtsRow, upsertMemoryFts } from "../../memory/fts";
 import { clampMemoryType } from "../../memory/canonicalTypes";
 import type {
   Env,
@@ -486,6 +486,7 @@ export async function supersedeMemory(
       .bind(nextId, input.namespace, newFactKey, input.reason ?? null, input.validAsOf ?? null, now)
       .run();
     await syncMemoryVector(env, { namespace: input.namespace, id: nextId });
+    await upsertMemoryFts(env.DB, { namespace: input.namespace, memoryId: nextId, content: input.newContent });
     return { oldStatus: "missing", newId: nextId };
   }
 
@@ -556,6 +557,7 @@ export async function supersedeMemory(
 
   // 3. 同步向量：新条目 upsert，旧条目下架
   await syncMemoryVector(env, { namespace: input.namespace, id: nextId });
+  await upsertMemoryFts(env.DB, { namespace: input.namespace, memoryId: nextId, content: input.newContent });
   if (old.vector_id) {
     for (let attempt = 0; attempt < 2; attempt += 1) {
       try {
@@ -641,6 +643,7 @@ export async function archiveMemory(
     .prepare("UPDATE memories SET status = 'archived', updated_at = ? WHERE namespace = ? AND id = ?")
     .bind(now, input.namespace, input.id)
     .run();
+  await deleteFtsRow(db, "memory_fts", "memory_id", input.id);
 
   if (existing.vector_id) {
     try {
@@ -680,6 +683,7 @@ export async function deleteMemoryV2(
     .prepare("DELETE FROM memories WHERE namespace = ? AND id = ?")
     .bind(input.namespace, input.id)
     .run();
+  await deleteFtsRow(db, "memory_fts", "memory_id", input.id);
   return true;
 }
 

--- a/src/gateway/handler.ts
+++ b/src/gateway/handler.ts
@@ -72,8 +72,19 @@ export async function recallPatch(
     )
     : [];
 
-  const quoteEntries = quotes.map((hit) => ({ kind: "quote", content: formatQuote(hit), id: hit.id }));
-  const regularHits = recall.hits.filter((hit) => !quotes.some((quote) => quoteOverlaps(hit.content, quote.content)));
+  const quoteEntries = quotes.map((hit) => ({
+    kind: "quote",
+    content: formatQuote(hit),
+    id: hit.id,
+    excerpt: hit.excerpt
+  }));
+  const droppedAsQuoteDup = recall.hits.filter((hit) =>
+    quotes.some((quote) => quoteOverlaps(hit.content, quote.excerpt || quote.content))
+  );
+  const regularHits = recall.hits.filter((hit) => !droppedAsQuoteDup.some((dup) => dup.id === hit.id));
+  const droppedPrecious = precious
+    .filter((row) => !relevantPrecious.some((kept) => kept.id === row.id))
+    .slice(0, 12);
   const assembled = assembleRecallSurface([
     ...(evidence ? quoteEntries : []),
     ...relevantPrecious.map(p => ({ kind: "precious", content: p.content, id: p.id })),
@@ -101,6 +112,7 @@ export async function recallPatch(
     recall_id: recallId,
     identity: identity.slug,
     query: query.slice(0, 80),
+    tokens: shaped.lexicalTokens.slice(0, 12),
     thin: shaped.thin,
     evidence,
     channels: {
@@ -108,8 +120,23 @@ export async function recallPatch(
       quotes: quotes.length,
       regular_hits: regularHits.length,
       week_blocks: weekBlocks.length,
-      dropped_as_quote_dup: recall.hits.length - regularHits.length
+      dropped_as_quote_dup: droppedAsQuoteDup.length
     },
+    items: assembled.entries.map((entry) => ({
+      id: entry.id ?? null,
+      kind: entry.kind,
+      reason: entry.kind === "quote"
+        ? "quote_excerpt"
+        : entry.kind === "precious"
+          ? "precious_lexical"
+          : entry.kind === "authored"
+            ? "authored_verbatim"
+            : "recall_hit"
+    })),
+    excluded: [
+      ...droppedAsQuoteDup.map((hit) => ({ id: hit.id, reason: "quote_dup_on_excerpt" })),
+      ...droppedPrecious.map((row) => ({ id: row.id, reason: "precious_not_relevant" }))
+    ].slice(0, 24),
     injected: assembled.entries.length,
     kinds: assembled.entries.map((entry) => entry.kind),
     budget: { maxItems: budget.maxItems, maxChars: budget.maxChars }

--- a/src/gateway/record.ts
+++ b/src/gateway/record.ts
@@ -58,14 +58,14 @@ export async function persistExchange(env: Env, e: GatewayExchange): Promise<voi
   if (e.kind !== "auxiliary") {
     statements.push(env.DB.prepare(`INSERT OR IGNORE INTO conversations (id, namespace, created_at, updated_at) VALUES (?, ?, ?, ?)`)
       .bind(e.conversationId, e.namespace, e.createdAt, e.createdAt));
-    const addMessage = (id: string, role: string, content: string) => statements.push(env.DB.prepare(`INSERT OR IGNORE INTO messages
+    const addMessage = (id: string, role: string, content: string, seq: number) => statements.push(env.DB.prepare(`INSERT OR IGNORE INTO messages
       (id, conversation_id, namespace, role, content, source, client_message_hash, upstream_model,
-       upstream_provider, request_model, stream, finish_reason, created_at)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+       upstream_provider, request_model, stream, finish_reason, created_at, seq)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
       .bind(id, e.conversationId, e.namespace, role, content, "gateway:" + e.profile, id,
-        e.model, e.provider, e.profile, e.stream ? 1 : 0, e.completion, e.createdAt));
-    if (e.kind === "human" && e.userText && e.completion !== "truncated") addMessage(e.userId, "user", e.userText);
-    if (e.completion === "complete" && e.assistantText) addMessage(e.id + ":assistant", "assistant", e.assistantText);
+        e.model, e.provider, e.profile, e.stream ? 1 : 0, e.completion, e.createdAt, seq));
+    if (e.kind === "human" && e.userText && e.completion !== "truncated") addMessage(e.userId, "user", e.userText, 0);
+    if (e.completion === "complete" && e.assistantText) addMessage(e.id + ":assistant", "assistant", e.assistantText, 1);
   }
   await env.DB.batch(statements);
   if (e.kind !== "auxiliary") {
@@ -112,10 +112,10 @@ export async function persistHumanUtterance(
       .bind(e.conversationId, e.namespace, e.createdAt, e.createdAt),
     env.DB.prepare(`INSERT OR IGNORE INTO messages
       (id, conversation_id, namespace, role, content, source, client_message_hash, upstream_model,
-       upstream_provider, request_model, stream, finish_reason, created_at)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+       upstream_provider, request_model, stream, finish_reason, created_at, seq)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
       .bind(e.userId, e.conversationId, e.namespace, "user", e.userText, "gateway:" + e.profile, e.userId,
-        e.model, e.provider, e.profile, e.stream ? 1 : 0, e.completion, e.createdAt)
+        e.model, e.provider, e.profile, e.stream ? 1 : 0, e.completion, e.createdAt, 0)
   ]);
   const indexed = await upsertMessageFts(env.DB, {
     namespace: e.namespace,

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,7 @@ import { handleModels } from "./api/models";
 import { handleRelationsGraph } from "./api/relations";
 import { runCandidateJudge } from "./memory/candidateJudge";
 import { runDailyMemoryDigest, runDreamBackfill } from "./memory/dailyDigest";
+import { backfillFts } from "./memory/fts";
 import {
   runDiaryTrigger,
   runGithubDailyTrigger,
@@ -304,6 +305,19 @@ export default {
             ]);
             results.push({ type: "retention", result: retentionResult });
             results.push({ type: "github_daily", result: githubResult });
+
+            try {
+              results.push({
+                type: "fts_backfill",
+                result: await backfillFts(env.DB, { namespace, limit: 400 })
+              });
+            } catch (error) {
+              console.error("scheduled fts backfill failed", {
+                namespace,
+                error: error instanceof Error ? error.message : String(error)
+              });
+              results.push({ type: "fts_backfill", result: { ok: false, error: String(error) } });
+            }
 
             let weeklyRollup: Awaited<ReturnType<typeof runWeeklyRollupTrigger>> | undefined;
             try {

--- a/src/memory/candidateJudge.ts
+++ b/src/memory/candidateJudge.ts
@@ -39,13 +39,6 @@ export interface JudgeRunResult {
   reason?: "judge_disabled" | "missing_model" | "no_candidates";
 }
 
-interface JudgeModelResult {
-  score: number;
-  grounded: boolean;
-  durable: boolean;
-  reason: string;
-}
-
 function readPositiveInt(value: unknown, fallback: number, max: number): number {
   const parsed = typeof value === "string" ? Number(value) : typeof value === "number" ? value : fallback;
   const numeric = Number.isFinite(parsed) ? parsed : fallback;
@@ -69,6 +62,77 @@ function parseJsonArray(raw: string | null): string[] {
   return [];
 }
 
+export type JudgeKind = "add" | "update" | "delete";
+export type JudgeDecision = "approve" | "discard" | "keep";
+
+export interface JudgeModelResult {
+  score: number;
+  grounded: boolean;
+  durable: boolean;
+  shouldDelete: boolean | null;
+  reason: string;
+}
+
+export function judgeKindFor(source: string): JudgeKind {
+  if (source === "dream_delete") return "delete";
+  if (source === "dream_update") return "update";
+  return "add";
+}
+
+export function parseJudgeBoolean(value: unknown): boolean | null {
+  if (value === true) return true;
+  if (value === false) return false;
+  if (value === 1) return true;
+  if (value === 0) return false;
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase();
+    if (normalized === "true" || normalized === "yes" || normalized === "1") return true;
+    if (normalized === "false" || normalized === "no" || normalized === "0") return false;
+  }
+  return null;
+}
+
+export function parseJudgeModelResult(raw: unknown): JudgeModelResult | null {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null;
+  const obj = raw as Record<string, unknown>;
+  const score = typeof obj.score === "number" && Number.isFinite(obj.score)
+    ? Math.min(Math.max(obj.score, 0), 1)
+    : null;
+  if (score === null) return null;
+  const grounded = parseJudgeBoolean(obj.grounded);
+  const durable = parseJudgeBoolean(obj.durable);
+  if (grounded === null || durable === null) return null;
+  return {
+    score,
+    grounded,
+    durable,
+    shouldDelete: parseJudgeBoolean(obj.should_delete),
+    reason: typeof obj.reason === "string" && obj.reason.trim()
+      ? obj.reason.trim().slice(0, 300)
+      : "(评审未给出理由)"
+  };
+}
+
+export function decideJudge(
+  kind: JudgeKind,
+  result: JudgeModelResult,
+  thresholds: { approveMin: number; discardMax: number }
+): JudgeDecision {
+  if (kind === "delete") {
+    // Approve only means "archive the target". Never infer that from a quality score.
+    if (result.shouldDelete === true && result.score >= thresholds.approveMin) return "approve";
+    if (result.shouldDelete === false) return "discard";
+    // Old prompts score "this fact is still good" high. That is evidence against deletion.
+    if (result.grounded && result.durable) return "discard";
+    if (result.score <= thresholds.discardMax) return "discard";
+    return "keep";
+  }
+
+  if (result.score >= thresholds.approveMin && result.grounded && result.durable) return "approve";
+  if (result.score <= thresholds.discardMax || !result.grounded || !result.durable) return "discard";
+  return "keep";
+}
+
 function formatTranscript(messages: MessageRecord[]): string {
   return messages
     .map((message) => {
@@ -78,34 +142,90 @@ function formatTranscript(messages: MessageRecord[]): string {
     .join("\n\n");
 }
 
-function buildJudgePrompt(candidate: MemoryCandidateRow, messages: MessageRecord[]): string {
+export function buildJudgePrompt(candidate: MemoryCandidateRow, messages: MessageRecord[]): string {
   const tags = parseJsonArray(candidate.tags);
   const transcript = messages.length > 0 ? formatTranscript(messages) : "(没有能核对的原始消息)";
-  return [
-    "你是 Aelios 记忆候选队列的自动评审员。任务：判断一条待审记忆候选该自动通过、自动丢弃，还是留给人工复核。",
+  const kind = judgeKindFor(candidate.source);
+  const common = [
+    "你是 Aelios 记忆候选队列的自动评审员。",
     "只输出 JSON，不要 markdown，不要解释，不要输出思考过程。",
-    "",
-    "打分依据 (score 是 0 到 1 的浮点数，综合以下三点)：",
-    "- grounded (是否有据)：候选内容必须能在下面的原始对话片段里找到依据，不能是编造或过度引申；找不到依据必须 grounded=false。",
-    "- durable (是否长期稳定)：这条记忆一个月后是否还成立；临时计划、一次性情绪、当次任务不算稳定事实。",
-    "- non-trivial (是否值得占用长期记忆位)：不是可重新推导的寒暄，不是后端实现细节，不是纯调试噪音。",
-    "- 工程实现流水（文件路径、命令、debug 过程、部署配置、后端实现细节）即使 grounded 也压低分——这类内容有代码仓库和 git 史，不该占长期记忆位。",
-    "- 情感/关系类候选不因为内容长而扣分；带「」原话、写了 3-5 句的关系记忆是合格形态，不是啰嗦。",
-    "证据越扎实、越稳定、越非平凡，score 越高；grounded / durable 必须是布尔值；reason 是一句话说明理由。",
-    "",
-    "输出格式：",
-    JSON.stringify({ score: 0.9, grounded: true, durable: true, reason: "对话里用户明确说过这件事，且是长期稳定的事实。" }),
+    "grounded / durable / should_delete 必须是 JSON 布尔值 true 或 false，不要用字符串。",
     "",
     "待审候选：",
     JSON.stringify({
+      action: kind,
+      source: candidate.source,
       type: candidate.type,
       content: candidate.content,
       fact_key: candidate.fact_key,
+      target_memory_id: candidate.target_memory_id,
       tags
     }),
     "",
     "原始对话片段：",
     transcript
+  ];
+
+  if (kind === "delete") {
+    return [
+      "任务：判断一条「归档提案」该不该执行。approve 会把已有记忆归档，不是把内容写进长期记忆。",
+      "score 衡量的是「这条记忆应不应该删」，不是「这条事实好不好」。",
+      "- 仍然有据、仍然成立、仍然值得留着 → should_delete=false，score 低。",
+      "- 过时、被对话否定、重复噪音、或明确不再成立 → should_delete=true，score 高。",
+      "- 亲笔/用户明确要求记住的内容，除非用户后来收回，否则不要删。",
+      "输出格式：",
+      JSON.stringify({
+        score: 0.15,
+        grounded: true,
+        durable: true,
+        should_delete: false,
+        reason: "对话仍支持这条事实，应该保留而不是归档。"
+      }),
+      "",
+      ...common
+    ].join("\n");
+  }
+
+  if (kind === "update") {
+    return [
+      "任务：判断一条「更新提案」该不该用新内容替换旧记忆。",
+      "打分依据：",
+      "- grounded：新内容必须能在原始对话里找到依据。",
+      "- durable：更新后的版本一个月后仍成立。",
+      "- 必须是实质修正或版本更新，不是同义复述，也不是把原话指令整段写进事实。",
+      "score 高 = 应该采用这次更新。",
+      "输出格式：",
+      JSON.stringify({
+        score: 0.88,
+        grounded: true,
+        durable: true,
+        should_delete: false,
+        reason: "用户用新内容明确修正了旧事实。"
+      }),
+      "",
+      ...common
+    ].join("\n");
+  }
+
+  return [
+    "任务：判断一条「新增提案」该自动通过、自动丢弃，还是留给人工复核。",
+    "打分依据 (score 是 0 到 1 的浮点数)：",
+    "- grounded：候选内容必须能在原始对话片段里找到依据，不能是编造或过度引申。",
+    "- durable：一个月后是否还成立；临时计划、一次性情绪、当次任务不算稳定事实。",
+    "- non-trivial：不是寒暄、不是后端实现细节、不是纯调试噪音。",
+    "- 工程实现流水即使 grounded 也压低分。",
+    "- 情感/关系类候选不因为内容长而扣分。",
+    "score 高 = 值得新增为长期记忆。",
+    "输出格式：",
+    JSON.stringify({
+      score: 0.9,
+      grounded: true,
+      durable: true,
+      should_delete: false,
+      reason: "对话里用户明确说过这件事，且是长期稳定的事实。"
+    }),
+    "",
+    ...common
   ].join("\n");
 }
 
@@ -127,19 +247,7 @@ async function callJudgeModel(env: Env, model: string, prompt: string, meta: { i
     return null;
   }
 
-  const raw = extractJsonObject(text);
-  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null;
-
-  const obj = raw as Record<string, unknown>;
-  const score = typeof obj.score === "number" && Number.isFinite(obj.score) ? Math.min(Math.max(obj.score, 0), 1) : null;
-  if (score === null) return null;
-
-  return {
-    score,
-    grounded: Boolean(obj.grounded),
-    durable: Boolean(obj.durable),
-    reason: typeof obj.reason === "string" && obj.reason.trim() ? obj.reason.trim().slice(0, 300) : "(评审未给出理由)"
-  };
+  return parseJudgeModelResult(extractJsonObject(text));
 }
 
 // approve 的落库语义跟 dream 候选队列的 fact_key 分支一致：
@@ -255,7 +363,13 @@ export async function runCandidateJudge(
       let judgeResult: JudgeModelResult;
       if (messages.length === 0) {
         // 找不到任何原始消息可核对：直接判 ungrounded，不必浪费一次模型调用。
-        judgeResult = { score: 0, grounded: false, durable: false, reason: "没有可核对的原始消息，无法确认是否有据" };
+        judgeResult = {
+          score: 0,
+          grounded: false,
+          durable: false,
+          shouldDelete: null,
+          reason: "没有可核对的原始消息，无法确认是否有据"
+        };
       } else {
         const modelResult = await callJudgeModel(env, model, buildJudgePrompt(candidate, messages), { id: candidate.id });
         if (!modelResult) {
@@ -267,9 +381,10 @@ export async function runCandidateJudge(
       }
 
       judged += 1;
+      const decision = decideJudge(judgeKindFor(candidate.source), judgeResult, { approveMin, discardMax });
       const decisionNote = `judge: ${judgeResult.reason}`;
 
-      if (judgeResult.score >= approveMin && judgeResult.grounded && judgeResult.durable) {
+      if (decision === "approve") {
         const memoryId = await approveCandidate(env, namespace, candidate, tags, sourceMessageIds);
         await updateMemoryCandidateStatus(env.DB, {
           namespace,
@@ -279,7 +394,7 @@ export async function runCandidateJudge(
           decisionNote
         });
         approved += 1;
-      } else if (judgeResult.score <= discardMax || !judgeResult.grounded || !judgeResult.durable) {
+      } else if (decision === "discard") {
         await updateMemoryCandidateStatus(env.DB, {
           namespace,
           id: candidate.id,

--- a/src/memory/diaryWriter.ts
+++ b/src/memory/diaryWriter.ts
@@ -95,13 +95,13 @@ async function listMessagesTailInRange(
 ): Promise<MessageRecord[]> {
   const result = await db
     .prepare(
-      `SELECT id, conversation_id, namespace, role, content, source, created_at
+      `SELECT id, conversation_id, namespace, role, content, source, created_at, seq
        FROM messages
        WHERE namespace = ?
          AND role IN ('user', 'assistant')
          AND created_at >= ?
          AND created_at < ?
-       ORDER BY created_at DESC, id DESC
+       ORDER BY created_at DESC, seq DESC, CASE role WHEN 'user' THEN 0 WHEN 'assistant' THEN 1 ELSE 2 END DESC, id DESC
        LIMIT ?`
     )
     .bind(input.namespace, input.startCreatedAt, input.endCreatedAt, input.limit)

--- a/src/memory/fts.ts
+++ b/src/memory/fts.ts
@@ -1,5 +1,12 @@
 import { tokenizeForIndex } from "./queryShape";
 
+const FTS_WRITE_ATTEMPTS = 3;
+
+function isMissingFtsError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return /no such (table|module)|fts5/i.test(message);
+}
+
 export function toFtsBody(text: string): string {
   return tokenizeForIndex(text).join(" ");
 }
@@ -13,13 +20,37 @@ export function toFtsMatch(tokens: string[]): string {
     .join(" OR ");
 }
 
+async function withRetry<T>(fn: () => Promise<T>, label: string, meta: Record<string, unknown>): Promise<T> {
+  let last: unknown;
+  for (let attempt = 0; attempt < FTS_WRITE_ATTEMPTS; attempt += 1) {
+    try {
+      return await fn();
+    } catch (error) {
+      last = error;
+      if (isMissingFtsError(error) || attempt === FTS_WRITE_ATTEMPTS - 1) {
+        if (!isMissingFtsError(error)) console.error(label, { ...meta, attempt: attempt + 1, error });
+        break;
+      }
+    }
+  }
+  throw last;
+}
+
 export async function deleteFtsRow(
   db: D1Database,
   table: "message_fts" | "memory_fts",
   idColumn: "message_id" | "memory_id",
   id: string
 ): Promise<void> {
-  await db.prepare(`DELETE FROM ${table} WHERE ${idColumn} = ?`).bind(id).run();
+  try {
+    await withRetry(
+      () => db.prepare(`DELETE FROM ${table} WHERE ${idColumn} = ?`).bind(id).run(),
+      "fts delete failed",
+      { table, id }
+    );
+  } catch {
+    // Search already falls back to LIKE; a stale row is worse than a missing one only if content changed.
+  }
 }
 
 export async function upsertMessageFts(
@@ -29,14 +60,16 @@ export async function upsertMessageFts(
   const body = toFtsBody(input.content);
   if (!body) return false;
   try {
-    await deleteFtsRow(db, "message_fts", "message_id", input.messageId);
-    await db
-      .prepare("INSERT INTO message_fts (fts_body, namespace, message_id) VALUES (?, ?, ?)")
-      .bind(body, input.namespace, input.messageId)
-      .run();
+    await withRetry(async () => {
+      await db.prepare("DELETE FROM message_fts WHERE message_id = ?").bind(input.messageId).run();
+      await db
+        .prepare("INSERT INTO message_fts (fts_body, namespace, message_id) VALUES (?, ?, ?)")
+        .bind(body, input.namespace, input.messageId)
+        .run();
+    }, "message fts index failed", { id: input.messageId });
     return true;
   } catch (error) {
-    console.error("message fts index failed", { id: input.messageId, error });
+    if (!isMissingFtsError(error)) console.error("message fts index failed", { id: input.messageId, error });
     return false;
   }
 }
@@ -48,14 +81,16 @@ export async function upsertMemoryFts(
   const body = toFtsBody(input.content);
   if (!body) return false;
   try {
-    await deleteFtsRow(db, "memory_fts", "memory_id", input.memoryId);
-    await db
-      .prepare("INSERT INTO memory_fts (fts_body, namespace, memory_id) VALUES (?, ?, ?)")
-      .bind(body, input.namespace, input.memoryId)
-      .run();
+    await withRetry(async () => {
+      await db.prepare("DELETE FROM memory_fts WHERE memory_id = ?").bind(input.memoryId).run();
+      await db
+        .prepare("INSERT INTO memory_fts (fts_body, namespace, memory_id) VALUES (?, ?, ?)")
+        .bind(body, input.namespace, input.memoryId)
+        .run();
+    }, "memory fts index failed", { id: input.memoryId });
     return true;
   } catch (error) {
-    console.error("memory fts index failed", { id: input.memoryId, error });
+    if (!isMissingFtsError(error)) console.error("memory fts index failed", { id: input.memoryId, error });
     return false;
   }
 }
@@ -73,13 +108,173 @@ export async function searchFtsIds(
       .prepare(
         `SELECT ${idColumn} AS id FROM ${table}
          WHERE ${table} MATCH ? AND namespace = ?
+         ORDER BY bm25(${table})
          LIMIT ?`
       )
       .bind(match, input.namespace, input.limit)
       .all<{ id: string }>();
     return (result.results ?? []).map((row) => row.id).filter(Boolean);
-  } catch (error) {
-    console.error("fts search failed", { table, error });
-    return [];
+  } catch (rankedError) {
+    if (isMissingFtsError(rankedError)) return [];
+    try {
+      const result = await db
+        .prepare(
+          `SELECT ${idColumn} AS id FROM ${table}
+           WHERE ${table} MATCH ? AND namespace = ?
+           LIMIT ?`
+        )
+        .bind(match, input.namespace, input.limit)
+        .all<{ id: string }>();
+      return (result.results ?? []).map((row) => row.id).filter(Boolean);
+    } catch (error) {
+      if (!isMissingFtsError(error)) console.error("fts search failed", { table, error, rankedError });
+      return [];
+    }
   }
+}
+
+export interface FtsBackfillResult {
+  messagesIndexed: number;
+  memoriesIndexed: number;
+  messageOrphansPurged: number;
+  memoryOrphansPurged: number;
+  failed: number;
+}
+
+async function indexMissingMessages(
+  db: D1Database,
+  input: { namespace?: string; limit: number }
+): Promise<{ indexed: number; failed: number }> {
+  const scoped = Boolean(input.namespace);
+  const sql = scoped
+    ? `SELECT m.id, m.namespace, m.content
+       FROM messages m
+       LEFT JOIN message_fts f ON f.message_id = m.id
+       WHERE m.namespace = ? AND f.message_id IS NULL
+         AND m.role IN ('user', 'assistant')
+       LIMIT ?`
+    : `SELECT m.id, m.namespace, m.content
+       FROM messages m
+       LEFT JOIN message_fts f ON f.message_id = m.id
+       WHERE f.message_id IS NULL AND m.role IN ('user', 'assistant')
+       LIMIT ?`;
+  const result = scoped
+    ? await db.prepare(sql).bind(input.namespace, input.limit).all<{ id: string; namespace: string; content: string }>()
+    : await db.prepare(sql).bind(input.limit).all<{ id: string; namespace: string; content: string }>();
+
+  let indexed = 0;
+  let failed = 0;
+  for (const row of result.results ?? []) {
+    const ok = await upsertMessageFts(db, { namespace: row.namespace, messageId: row.id, content: row.content });
+    if (ok) indexed += 1;
+    else failed += 1;
+  }
+  return { indexed, failed };
+}
+
+async function indexMissingMemories(
+  db: D1Database,
+  input: { namespace?: string; limit: number }
+): Promise<{ indexed: number; failed: number }> {
+  const scoped = Boolean(input.namespace);
+  const sql = scoped
+    ? `SELECT m.id, m.namespace, m.content, m.summary
+       FROM memories m
+       LEFT JOIN memory_fts f ON f.memory_id = m.id
+       WHERE m.namespace = ? AND f.memory_id IS NULL
+         AND m.status = 'active'
+       LIMIT ?`
+    : `SELECT m.id, m.namespace, m.content, m.summary
+       FROM memories m
+       LEFT JOIN memory_fts f ON f.memory_id = m.id
+       WHERE f.memory_id IS NULL AND m.status = 'active'
+       LIMIT ?`;
+  const result = scoped
+    ? await db.prepare(sql).bind(input.namespace, input.limit).all<{ id: string; namespace: string; content: string; summary: string | null }>()
+    : await db.prepare(sql).bind(input.limit).all<{ id: string; namespace: string; content: string; summary: string | null }>();
+
+  let indexed = 0;
+  let failed = 0;
+  for (const row of result.results ?? []) {
+    const ok = await upsertMemoryFts(db, {
+      namespace: row.namespace,
+      memoryId: row.id,
+      content: `${row.content}\n${row.summary ?? ""}`
+    });
+    if (ok) indexed += 1;
+    else failed += 1;
+  }
+  return { indexed, failed };
+}
+
+export async function purgeOrphanFts(db: D1Database): Promise<{ messages: number; memories: number }> {
+  let messages = 0;
+  let memories = 0;
+  try {
+    const msg = await db.prepare(
+      `DELETE FROM message_fts WHERE message_id NOT IN (SELECT id FROM messages)`
+    ).run();
+    messages = msg.meta.changes ?? 0;
+  } catch (error) {
+    console.error("message fts orphan purge failed", error);
+  }
+  try {
+    const mem = await db.prepare(
+      `DELETE FROM memory_fts WHERE memory_id NOT IN (SELECT id FROM memories WHERE status = 'active')`
+    ).run();
+    memories = mem.meta.changes ?? 0;
+  } catch (error) {
+    console.error("memory fts orphan purge failed", error);
+  }
+  return { messages, memories };
+}
+
+export async function backfillFts(
+  db: D1Database,
+  input: { namespace?: string; limit?: number } = {}
+): Promise<FtsBackfillResult> {
+  const limit = Math.min(Math.max(input.limit ?? 200, 1), 1000);
+  let messagesIndexed = 0;
+  let memoriesIndexed = 0;
+  let failed = 0;
+  try {
+    const messages = await indexMissingMessages(db, { namespace: input.namespace, limit });
+    messagesIndexed = messages.indexed;
+    failed += messages.failed;
+  } catch (error) {
+    console.error("message fts backfill failed", error);
+  }
+  try {
+    const memories = await indexMissingMemories(db, { namespace: input.namespace, limit });
+    memoriesIndexed = memories.indexed;
+    failed += memories.failed;
+  } catch (error) {
+    console.error("memory fts backfill failed", error);
+  }
+  const purged = await purgeOrphanFts(db);
+  return {
+    messagesIndexed,
+    memoriesIndexed,
+    messageOrphansPurged: purged.messages,
+    memoryOrphansPurged: purged.memories,
+    failed
+  };
+}
+
+export async function rebuildFts(
+  db: D1Database,
+  input: { namespace?: string; limit?: number } = {}
+): Promise<FtsBackfillResult> {
+  try {
+    if (input.namespace) {
+      await db.prepare("DELETE FROM message_fts WHERE namespace = ?").bind(input.namespace).run();
+      await db.prepare("DELETE FROM memory_fts WHERE namespace = ?").bind(input.namespace).run();
+    } else {
+      await db.prepare("DELETE FROM message_fts").run();
+      await db.prepare("DELETE FROM memory_fts").run();
+    }
+  } catch (error) {
+    console.error("fts rebuild truncate failed", error);
+  }
+  return backfillFts(db, input);
 }

--- a/src/memory/queryShape.ts
+++ b/src/memory/queryShape.ts
@@ -54,9 +54,8 @@ export function tokenizeQuery(text: string): string[] {
   return [...tokens].slice(0, 12);
 }
 
-export function tokenizeForIndex(text: string, limit = 40): string[] {
+function collectIndexTokens(norm: string): string[] {
   const tokens = new Set<string>();
-  const norm = text.toLowerCase();
 
   for (const word of norm.split(/[^a-z0-9\u4e00-\u9fff]+/)) {
     if (word.length >= 2 && !STOP.has(word)) tokens.add(word);
@@ -78,7 +77,19 @@ export function tokenizeForIndex(text: string, limit = 40): string[] {
     if (code.length >= 2 && !STOP.has(code)) tokens.add(code);
   }
 
-  return [...tokens].slice(0, limit);
+  return [...tokens];
+}
+
+export function tokenizeForIndex(text: string, limit = 80): string[] {
+  const norm = text.toLowerCase();
+  if (norm.length <= 480) return collectIndexTokens(norm).slice(0, limit);
+
+  const head = collectIndexTokens(norm.slice(0, 480));
+  const tail = collectIndexTokens(norm.slice(-480));
+  const merged = [...new Set([...head, ...tail])];
+  if (merged.length <= limit) return merged;
+  const headKeep = Math.ceil(limit * 0.6);
+  return [...new Set([...head.slice(0, headKeep), ...tail.slice(-(limit - headKeep))])].slice(0, limit);
 }
 
 export function isEvidenceQuery(query: string): boolean {

--- a/src/memory/quotes.ts
+++ b/src/memory/quotes.ts
@@ -3,10 +3,13 @@ import type { MessageRecord } from "../types";
 import { searchFtsIds } from "./fts";
 import { isPreciousRelevant, lexicalOverlapScore, tokenizeForIndex } from "./queryShape";
 
+export const QUOTE_EXCERPT_CHARS = 280;
+
 export interface QuoteHit {
   id: string;
   role: "user" | "assistant" | string;
   content: string;
+  excerpt: string;
   created_at: string;
   conversation_id: string;
   score: number;
@@ -14,6 +17,49 @@ export interface QuoteHit {
 
 function escapeLike(value: string): string {
   return value.replace(/[\\%_]/g, (ch) => `\\${ch}`);
+}
+
+export function excerptAroundMatch(
+  content: string,
+  tokens: string[],
+  maxLen = QUOTE_EXCERPT_CHARS
+): string {
+  const text = content.replace(/\s+/g, " ").trim();
+  if (!text) return "";
+  if (text.length <= maxLen) return text;
+
+  const lower = text.toLowerCase();
+  let hit = -1;
+  let hitLen = 0;
+  for (const token of tokens) {
+    const needle = token.trim().toLowerCase();
+    if (needle.length < 2) continue;
+    const idx = lower.indexOf(needle);
+    if (idx >= 0 && (hit < 0 || idx < hit)) {
+      hit = idx;
+      hitLen = needle.length;
+    }
+  }
+  if (hit < 0) return text.slice(0, maxLen);
+
+  const window = Math.max(maxLen - hitLen, 32);
+  const before = Math.min(Math.floor(window / 3), hit);
+  let start = hit - before;
+  if (start + maxLen > text.length) start = Math.max(0, text.length - maxLen);
+  const chunk = text.slice(start, start + maxLen);
+  return `${start > 0 ? "…" : ""}${chunk}${start + chunk.length < text.length ? "…" : ""}`;
+}
+
+function toQuoteHit(row: MessageRecord, tokens: string[]): QuoteHit {
+  return {
+    id: row.id,
+    role: row.role,
+    content: row.content,
+    excerpt: excerptAroundMatch(row.content, tokens),
+    created_at: row.created_at,
+    conversation_id: row.conversation_id,
+    score: lexicalOverlapScore(row.content, tokens)
+  };
 }
 
 async function searchQuotesLike(
@@ -37,14 +83,7 @@ async function searchQuotesLike(
 
   return (result.results ?? [])
     .filter((row) => !input.excludeIds.has(row.id))
-    .map((row) => ({
-      id: row.id,
-      role: row.role,
-      content: row.content,
-      created_at: row.created_at,
-      conversation_id: row.conversation_id,
-      score: lexicalOverlapScore(row.content, tokens)
-    }))
+    .map((row) => toQuoteHit(row, tokens))
     .filter((row) => row.score > 0 && isPreciousRelevant(row.content, tokens))
     .sort((a, b) => b.score - a.score || b.created_at.localeCompare(a.created_at));
 }
@@ -70,14 +109,7 @@ export async function searchQuotes(
   const fromFts = ftsIds.length
     ? (await getMessagesByIds(db, { namespace: input.namespace, ids: ftsIds }))
       .filter((row) => !excludeIds.has(row.id) && (row.role === "user" || row.role === "assistant"))
-      .map((row) => ({
-        id: row.id,
-        role: row.role,
-        content: row.content,
-        created_at: row.created_at,
-        conversation_id: row.conversation_id,
-        score: lexicalOverlapScore(row.content, tokens)
-      }))
+      .map((row) => toQuoteHit(row, tokens))
       .filter((row) => row.score > 0 && isPreciousRelevant(row.content, tokens))
     : [];
 
@@ -96,7 +128,8 @@ function clusterQuotes(hits: QuoteHit[], limit: number): QuoteHit[] {
   for (const hit of hits.sort((a, b) => b.score - a.score || b.created_at.localeCompare(a.created_at))) {
     const duplicate = kept.some((other) =>
       other.conversation_id === hit.conversation_id
-      && (other.content.includes(hit.content) || hit.content.includes(other.content))
+      && (other.excerpt.includes(hit.excerpt) || hit.excerpt.includes(other.excerpt)
+        || other.content.includes(hit.content) || hit.content.includes(other.content))
     );
     if (duplicate) continue;
     kept.push(hit);
@@ -108,7 +141,7 @@ function clusterQuotes(hits: QuoteHit[], limit: number): QuoteHit[] {
 export function formatQuote(hit: QuoteHit): string {
   const day = hit.created_at.slice(0, 10);
   const speaker = hit.role === "assistant" ? "助手" : "用户";
-  const quote = hit.content.replace(/\s+/g, " ").trim().slice(0, 280);
+  const quote = (hit.excerpt || excerptAroundMatch(hit.content, [])).replace(/\s+/g, " ").trim();
   return `${day} ${speaker}: 「${quote}」`;
 }
 

--- a/src/memory/rememberNow.ts
+++ b/src/memory/rememberNow.ts
@@ -3,39 +3,76 @@ import type { Env } from "../types";
 import { sha256Hex } from "../utils/hash";
 import { upsertMemoryFts } from "./fts";
 
-const REMEMBER_RE = /^(?:请)?(?:帮我)?(?:记住|记一下)(?:一下|了)?[：:，,\s]*(.+)$/s;
-const REMEMBER_EN_RE = /^(?:please\s+)?remember(?:\s+that)?[：:\s]+(.+)$/is;
+export type RememberKind = "save" | "probe" | "recollect";
 
-export function parseRememberNow(text: string): string | null {
+export interface RememberParse {
+  kind: RememberKind;
+  content?: string;
+}
+
+const REMEMBER_RE = /^(?:请)?(?:帮我)?(?:记住|记一下)(?:一下)?[：:，,\s]*(.+)$/s;
+const REMEMBER_EN_RE = /^(?:please\s+)?remember(?:\s+that)?[：:\s]+(.+)$/is;
+const PROBE_RE =
+  /^(?:你)?(?:还)?(?:请)?(?:帮我)?(?:记住了吗|记住了么|记住了没|记住了嘛|记得吗|记得了吗|记住了|did you remember|have you remembered)[\s?？!！.。]*$/i;
+const RECOLLECT_RE =
+  /^(?:please\s+)?remember\s+(?:when|how|if|what|who|why|whether|the time)\b/i;
+const INSTRUCTION_TAIL_RE =
+  /[。.!！；;]\s*(?:只(?:回复|回|说|答|回三个字)[^。.!！]*|(?:请)?只(?:用|回复|回|说)[^。.!！]*|不要[^。.!！]*|(?:only|just)\s+(?:reply|say|respond|answer|output)[^.!]*|do not\b[^.!]*|don't\b[^.!]*)\s*$/i;
+
+function stripInstructionTail(content: string): string {
+  let text = content.replace(/\s+/g, " ").trim();
+  for (let i = 0; i < 3; i += 1) {
+    const next = text.replace(INSTRUCTION_TAIL_RE, "").trim();
+    if (next === text) break;
+    text = next;
+  }
+  return text;
+}
+
+export function classifyRememberUtterance(text: string): RememberParse | null {
   const trimmed = text.trim();
   if (!trimmed) return null;
+  if (PROBE_RE.test(trimmed)) return { kind: "probe" };
+  if (RECOLLECT_RE.test(trimmed)) return { kind: "recollect" };
+  if (/[?？]\s*$/.test(trimmed)) return { kind: "probe" };
+
   for (const pattern of [REMEMBER_RE, REMEMBER_EN_RE]) {
     const match = trimmed.match(pattern);
-    const content = match?.[1]?.trim();
-    if (content && content.length >= 2) return content.slice(0, 2000);
+    const raw = match?.[1]?.trim();
+    if (!raw) continue;
+    const content = stripInstructionTail(raw);
+    if (content.length < 2) return { kind: "probe" };
+    if (/^[吗么呢吧啊呀]+[?？!！.。]*$/.test(content)) return { kind: "probe" };
+    return { kind: "save", content: content.slice(0, 2000) };
   }
   return null;
+}
+
+export function parseRememberNow(text: string): string | null {
+  const parsed = classifyRememberUtterance(text);
+  return parsed?.kind === "save" && parsed.content ? parsed.content : null;
 }
 
 export async function captureRememberNow(
   env: Env,
   input: { namespace: string; userText: string; messageId?: string }
 ): Promise<{ wrote: boolean; indexed?: boolean; id?: string; content?: string }> {
-  const content = parseRememberNow(input.userText);
-  if (!content) return { wrote: false };
+  const classified = classifyRememberUtterance(input.userText);
+  if (classified?.kind !== "save" || !classified.content) return { wrote: false };
 
-  const factKey = `remember:${(await sha256Hex(content.toLowerCase())).slice(0, 24)}`;
+  const content = classified.content;
+  // Idempotent on exact verbatim text only. Topic versioning is Dream's job.
+  const factKey = `verbatim:${(await sha256Hex(content.toLowerCase())).slice(0, 24)}`;
   const result = await upsertMemoryByFactKey(env, {
     namespace: input.namespace,
     factKey,
     content,
-    type: "fact",
-    importance: 0.92,
-    confidence: 0.96,
-    tags: ["remember_now"],
+    type: "note",
+    importance: 0.78,
+    confidence: 0.7,
+    tags: ["remember_now", "verbatim"],
     source: "remember_now",
-    sourceMessageIds: input.messageId ? [input.messageId] : [],
-    authoredBy: "user"
+    sourceMessageIds: input.messageId ? [input.messageId] : []
   });
   const indexed = await upsertMemoryFts(env.DB, {
     namespace: input.namespace,

--- a/src/memory/retention.ts
+++ b/src/memory/retention.ts
@@ -10,6 +10,7 @@ import {
   writeCursor,
   RETENTION_BATCH_SIZE,
 } from "../db/retention";
+import { deleteFtsRow } from "./fts";
 import type { Env } from "../types";
 import { readPositiveInt } from "../utils/request";
 
@@ -97,6 +98,11 @@ export async function runMemoryRetention(
   // 5. Expire old active memories and sync Vectorize
   const expireResult = await expireOldMemories(env.DB, namespace, daysAgo(MEMORY_ACTIVE_EXPIRY_DAYS));
   stats.expiredMemories = expireResult.count;
+  if (expireResult.expired.length > 0) {
+    for (const memory of expireResult.expired) {
+      await deleteFtsRow(env.DB, "memory_fts", "memory_id", memory.id);
+    }
+  }
 
   // 5a. Sync Vectorize: remove vectors for newly expired memories
   if (env.VECTORIZE && expireResult.expired.length > 0) {

--- a/src/memory/vectorStore.ts
+++ b/src/memory/vectorStore.ts
@@ -3,6 +3,7 @@ import { newId } from "../utils/ids";
 import { clampScore, parseStringArray, readString } from "../utils/parse";
 import { nowIso } from "../utils/time";
 import { createEmbedding } from "./embedding";
+import { deleteFtsRow, upsertMemoryFts } from "./fts";
 import { clampMemoryType } from "./canonicalTypes";
 
 type MetadataMap = Record<string, unknown>;
@@ -227,6 +228,7 @@ async function insertMemoryRecord(env: Env, record: MemoryRecord): Promise<void>
 
   if (!isLifecycleEnabled(env)) {
     await memoryInsert.run();
+    await upsertMemoryFts(env.DB, { namespace: record.namespace, memoryId: record.id, content: record.content });
     return;
   }
 
@@ -240,6 +242,7 @@ async function insertMemoryRecord(env: Env, record: MemoryRecord): Promise<void>
     .bind(record.id, record.namespace, record.created_at);
 
   await env.DB.batch([memoryInsert, lifecycleInsert]);
+  await upsertMemoryFts(env.DB, { namespace: record.namespace, memoryId: record.id, content: record.content });
 }
 
 async function getVectorsByIdsBatched(
@@ -313,6 +316,15 @@ async function updateMemoryRecord(env: Env, record: MemoryRecord): Promise<Memor
     )
     .run();
 
+  if (record.status === "deleted" || record.status === "archived" || record.status === "expired") {
+    await deleteFtsRow(env.DB, "memory_fts", "memory_id", record.id);
+  } else {
+    await upsertMemoryFts(env.DB, {
+      namespace: record.namespace,
+      memoryId: record.id,
+      content: `${record.content}\n${record.summary ?? ""}`
+    });
+  }
   return getMemoryRecordById(env, record.id);
 }
 
@@ -321,6 +333,7 @@ async function markMemoryRecordDeleted(env: Env, input: { namespace: string; id:
     .prepare("UPDATE memories SET status = 'deleted', updated_at = ? WHERE namespace = ? AND id = ?")
     .bind(input.updatedAt, input.namespace, input.id)
     .run();
+  await deleteFtsRow(env.DB, "memory_fts", "memory_id", input.id);
 }
 
 export async function createVectorMemory(env: Env, input: VectorMemoryInput): Promise<MemoryApiRecord> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -227,6 +227,8 @@ export interface MessageRecord {
   content: string;
   source: string | null;
   created_at: string;
+  /** Turn-local order. Hash IDs are unique only; same-timestamp rows sort by seq. */
+  seq?: number;
 }
 
 export type MemoryVersionStatus = "current" | "superseded" | "under_review";

--- a/tests/gateway.test.ts
+++ b/tests/gateway.test.ts
@@ -315,6 +315,26 @@ test("a topical follow-up does not inject the previous relationship precious", a
   assert.doesNotMatch(JSON.stringify(calls[0].query.messages), /Aelios memory reference|关系记忆|喜欢 Cloudflare/);
 });
 
+test("remember probes and recollection questions do not become facts", async () => {
+  await run("/v1/chat/completions", { model: "partner", messages: [{ role: "user", content: "记住了吗？" }] });
+  await run("/v1/chat/completions", { model: "partner", messages: [{ role: "user", content: "remember when we talked about the project?" }] });
+  await run("/v1/chat/completions", {
+    model: "partner",
+    messages: [{ role: "user", content: "请记住：暗号是芝麻开门。只回复三个字：记住了" }]
+  });
+  const rows = sqlite.prepare("SELECT content, type, tags, authored_by FROM memories").all() as Array<{
+    content: string;
+    type: string;
+    tags: string;
+    authored_by: string | null;
+  }>;
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0].content, "暗号是芝麻开门");
+  assert.equal(rows[0].type, "note");
+  assert.match(rows[0].tags, /verbatim/);
+  assert.equal(rows[0].authored_by, null);
+});
+
 test("please-remember writes the original words into long-term memory", async () => {
   const first = await run("/v1/chat/completions", {
     model: "partner",

--- a/tests/recall-quality.test.ts
+++ b/tests/recall-quality.test.ts
@@ -13,11 +13,23 @@ import { assembleRecallSurface, formatRecallSurface } from "../src/memory/surfac
 import { filterAndCompressMemoriesWithMeta } from "../src/memory/filter";
 import { formatDreamCursor, readDailyCursor } from "../src/memory/dreamDates";
 import { listMessagesByNamespaceInRange } from "../src/db/messages";
-import { parseRememberNow } from "../src/memory/rememberNow";
-import { formatQuote, searchQuotes } from "../src/memory/quotes";
+import {
+  classifyRememberUtterance,
+  parseRememberNow
+} from "../src/memory/rememberNow";
+import { excerptAroundMatch, formatQuote, quoteOverlaps, searchQuotes } from "../src/memory/quotes";
 import { isEvidenceQuery, isTemporalQuery, tokenizeForIndex } from "../src/memory/queryShape";
 import { searchMemoriesByText } from "../src/db/memories";
+import { backfillFts, rebuildFts, toFtsBody } from "../src/memory/fts";
+import {
+  decideJudge,
+  parseJudgeBoolean,
+  parseJudgeModelResult,
+  judgeKindFor,
+  buildJudgePrompt
+} from "../src/memory/candidateJudge";
 import { recentHumanTexts } from "../src/gateway/protocol";
+import type { MemoryCandidateRow } from "../src/db/v2/candidates";
 
 test("topical questions do not mix the previous turn into lexical tokens", () => {
   const shaped = shapeRecallQuery({
@@ -194,11 +206,11 @@ test("same-timestamp messages are not skipped after a mid-batch cut", async () =
   const sqlite = new DatabaseSync(":memory:");
   sqlite.exec(`CREATE TABLE messages (
     id TEXT PRIMARY KEY, conversation_id TEXT, namespace TEXT, role TEXT, content TEXT,
-    source TEXT, created_at TEXT
+    source TEXT, created_at TEXT, seq INTEGER NOT NULL DEFAULT 0
   )`);
   const ts = "2026-09-06T12:00:00.000Z";
-  sqlite.prepare("INSERT INTO messages VALUES (?, ?, ?, ?, ?, ?, ?)").run("msg_a", "c", "ns", "user", "先说", "gw", ts);
-  sqlite.prepare("INSERT INTO messages VALUES (?, ?, ?, ?, ?, ?, ?)").run("msg_b", "c", "ns", "assistant", "后说", "gw", ts);
+  sqlite.prepare("INSERT INTO messages VALUES (?, ?, ?, ?, ?, ?, ?, ?)").run("msg_a", "c", "ns", "user", "先说", "gw", ts, 0);
+  sqlite.prepare("INSERT INTO messages VALUES (?, ?, ?, ?, ?, ?, ?, ?)").run("msg_b", "c", "ns", "assistant", "后说", "gw", ts, 1);
   const db = {
     prepare(sql: string) {
       const statement = sqlite.prepare(sql);
@@ -255,10 +267,10 @@ test("raw utterances are searchable before they become facts", async () => {
   const sqlite = new DatabaseSync(":memory:");
   sqlite.exec(`CREATE TABLE messages (
     id TEXT PRIMARY KEY, conversation_id TEXT, namespace TEXT, role TEXT, content TEXT,
-    source TEXT, created_at TEXT
+    source TEXT, created_at TEXT, seq INTEGER NOT NULL DEFAULT 0
   )`);
-  sqlite.prepare("INSERT INTO messages VALUES (?, ?, ?, ?, ?, ?, ?)").run(
-    "msg_1", "c", "ns", "user", "请记住调试暗号是芝麻开门", "gw", "2026-09-06T12:00:00.000Z"
+  sqlite.prepare("INSERT INTO messages VALUES (?, ?, ?, ?, ?, ?, ?, ?)").run(
+    "msg_1", "c", "ns", "user", "请记住调试暗号是芝麻开门", "gw", "2026-09-06T12:00:00.000Z", 0
   );
   const db = {
     prepare(sql: string) {
@@ -284,6 +296,15 @@ test("remember-now extracts the original words after the trigger", () => {
   assert.equal(parseRememberNow("帮我记一下：喜欢 Cloudflare"), "喜欢 Cloudflare");
   assert.equal(parseRememberNow("remember that the passphrase is sesame"), "the passphrase is sesame");
   assert.equal(parseRememberNow("我们喜欢什么？"), null);
+  assert.equal(parseRememberNow("记住了吗？"), null);
+  assert.equal(parseRememberNow("remember when we talked about the project?"), null);
+  assert.equal(
+    parseRememberNow("请记住：暗号是芝麻开门。只回复三个字：记住了"),
+    "暗号是芝麻开门"
+  );
+  assert.equal(classifyRememberUtterance("记住了吗？")?.kind, "probe");
+  assert.equal(classifyRememberUtterance("remember when we talked about the project?")?.kind, "recollect");
+  assert.equal(classifyRememberUtterance("请记住调试暗号是芝麻开门")?.kind, "save");
 });
 
 test("recentHumanTexts walks user turns in chronological order", () => {
@@ -296,4 +317,214 @@ test("recentHumanTexts walks user turns in chronological order", () => {
     ]
   }, "chat");
   assert.deepEqual(texts, ["先做网关", "那个呢？"]);
+});
+
+function wrapSqlite(sqlite: DatabaseSync) {
+  return {
+    prepare(sql: string) {
+      const statement = sqlite.prepare(sql);
+      let args: unknown[] = [];
+      const api = {
+        bind(...values: unknown[]) { args = values; return api; },
+        async all() { return { results: statement.all(...args) }; },
+        async first() { return statement.get(...args) || null; },
+        async run() { return { meta: { changes: statement.run(...args).changes } }; }
+      };
+      return api;
+    }
+  };
+}
+
+function memoriesSchema(sqlite: DatabaseSync): void {
+  sqlite.exec(`CREATE TABLE memories (
+    id TEXT PRIMARY KEY, namespace TEXT, type TEXT, content TEXT, summary TEXT,
+    importance REAL, confidence REAL, status TEXT, pinned INTEGER, tags TEXT,
+    source TEXT, source_message_ids TEXT, vector_id TEXT, last_recalled_at TEXT,
+    recall_count INTEGER DEFAULT 0, created_at TEXT, updated_at TEXT, expires_at TEXT,
+    version_status TEXT, fact_key TEXT, superseded_by TEXT, authored_by TEXT, response_tendency TEXT
+  )`);
+}
+
+test("judge does not archive a still-valid fact and rejects string booleans", () => {
+  const thresholds = { approveMin: 0.8, discardMax: 0.3 };
+  assert.equal(judgeKindFor("dream_delete"), "delete");
+  assert.equal(judgeKindFor("dream_update"), "update");
+  assert.equal(judgeKindFor("dream_add"), "add");
+  assert.equal(parseJudgeBoolean("false"), false);
+  assert.equal(parseJudgeBoolean("true"), true);
+  assert.equal(parseJudgeBoolean(false), false);
+  assert.equal(parseJudgeBoolean("maybe"), null);
+  assert.equal(parseJudgeModelResult({
+    score: 0.95,
+    grounded: "false",
+    durable: true,
+    reason: "string false must not coerce to true"
+  })?.grounded, false);
+  assert.equal(parseJudgeModelResult({ score: 0.9, grounded: "nope", durable: true }), null);
+
+  const goodFact = {
+    score: 0.94,
+    grounded: true,
+    durable: true,
+    shouldDelete: null,
+    reason: "对话里用户明确说过这件事，且是长期稳定的事实。"
+  };
+  assert.equal(decideJudge("delete", goodFact, thresholds), "discard");
+  assert.equal(decideJudge("add", goodFact, thresholds), "approve");
+  assert.equal(decideJudge("delete", { ...goodFact, shouldDelete: false, score: 0.99 }, thresholds), "discard");
+  assert.equal(decideJudge("delete", {
+    score: 0.91,
+    grounded: false,
+    durable: false,
+    shouldDelete: true,
+    reason: "已被用户否定，应该归档。"
+  }, thresholds), "approve");
+
+  const deletePrompt = buildJudgePrompt({
+    id: "cand_1",
+    namespace: "ns",
+    type: "fact",
+    content: "调试暗号是芝麻开门",
+    fact_key: "fact:pass",
+    confidence: 0.9,
+    importance: 0.9,
+    tags: "[]",
+    source_message_ids: "[]",
+    source: "dream_delete",
+    status: "pending",
+    target_memory_id: "mem_1",
+    decision_note: null,
+    created_at: "2026-09-06",
+    updated_at: "2026-09-06"
+  } as MemoryCandidateRow, []);
+  assert.match(deletePrompt, /归档提案|应不应该删/);
+  assert.doesNotMatch(deletePrompt, /score 高 = 值得新增/);
+});
+
+test("FTS id hits keep SQL binds aligned and still find the rows", async () => {
+  const sqlite = new DatabaseSync(":memory:");
+  memoriesSchema(sqlite);
+  sqlite.prepare(`INSERT INTO memories (
+    id, namespace, type, content, summary, importance, confidence, status, pinned, tags,
+    source, source_message_ids, vector_id, created_at, updated_at
+  ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`).run(
+    "mem_a", "ns", "note", "调试暗号是芝麻开门", null, 0.8, 0.8, "active", 0, "[]",
+    "extract", "[]", "v", "2026-09-01", "2026-09-01"
+  );
+  sqlite.prepare(`INSERT INTO memories (
+    id, namespace, type, content, summary, importance, confidence, status, pinned, tags,
+    source, source_message_ids, vector_id, created_at, updated_at
+  ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`).run(
+    "mem_b", "ns", "note", "备用暗号是芝麻开门", null, 0.8, 0.8, "active", 0, "[]",
+    "extract", "[]", "v", "2026-09-01", "2026-09-01"
+  );
+
+  const real = wrapSqlite(sqlite);
+  const db = {
+    prepare(sql: string) {
+      if (sql.includes("memory_fts") && sql.includes("MATCH")) {
+        const api = {
+          bind() { return api; },
+          async all() { return { results: [{ id: "mem_a" }, { id: "mem_b" }] }; }
+        };
+        return api;
+      }
+      return real.prepare(sql);
+    }
+  };
+
+  const hits = await searchMemoriesByText(db as any, {
+    namespace: "ns",
+    query: "我们喜欢什么？",
+    tokens: ["暗号", "芝麻"],
+    limit: 10
+  });
+  assert.equal(hits.length, 2);
+  assert.ok(hits.some((row) => row.id === "mem_a"));
+  assert.ok(hits.some((row) => row.id === "mem_b"));
+  sqlite.close();
+});
+
+test("same-timestamp gateway hashes keep ask-then-answer order", async () => {
+  const sqlite = new DatabaseSync(":memory:");
+  sqlite.exec(`CREATE TABLE messages (
+    id TEXT PRIMARY KEY, conversation_id TEXT, namespace TEXT, role TEXT, content TEXT,
+    source TEXT, created_at TEXT, seq INTEGER NOT NULL DEFAULT 0
+  )`);
+  const ts = "2026-09-06T12:00:00.000Z";
+  sqlite.prepare("INSERT INTO messages VALUES (?, ?, ?, ?, ?, ?, ?, ?)").run(
+    "gw_req_ffff", "c", "ns", "assistant", "芝麻开门", "gw", ts, 1
+  );
+  sqlite.prepare("INSERT INTO messages VALUES (?, ?, ?, ?, ?, ?, ?, ?)").run(
+    "gw_user_aaaa", "c", "ns", "user", "调试暗号是什么？", "gw", ts, 0
+  );
+  const rows = await listMessagesByNamespaceInRange(wrapSqlite(sqlite) as any, {
+    namespace: "ns",
+    startCreatedAt: "2026-09-06T00:00:00.000Z",
+    endCreatedAt: "2026-09-07T00:00:00.000Z",
+    limit: 10
+  });
+  assert.deepEqual(rows.map((row) => row.role), ["user", "assistant"]);
+  assert.deepEqual(rows.map((row) => row.id), ["gw_user_aaaa", "gw_req_ffff"]);
+  sqlite.close();
+});
+
+test("quote excerpts keep the matched span and final-snippet dedup uses the excerpt", () => {
+  const prefix = "前言".repeat(80);
+  const content = `${prefix} 调试暗号是芝麻开门 ${"结尾".repeat(20)}`;
+  const excerpt = excerptAroundMatch(content, ["芝麻开门", "暗号"]);
+  assert.match(excerpt, /芝麻开门/);
+  assert.ok(excerpt.length <= 282);
+  const formatted = formatQuote({
+    id: "msg_long",
+    role: "user",
+    content,
+    excerpt,
+    created_at: "2026-09-06T12:00:00.000Z",
+    conversation_id: "c",
+    score: 1
+  });
+  assert.match(formatted, /芝麻开门/);
+  assert.ok(quoteOverlaps("调试暗号是芝麻开门", excerpt));
+  assert.equal(quoteOverlaps("完全无关的普通记忆", excerpt.slice(0, 12)), false);
+});
+
+test("FTS backfill indexes missing rows and can rebuild from source text", async () => {
+  const sqlite = new DatabaseSync(":memory:");
+  sqlite.exec(`CREATE TABLE messages (
+    id TEXT PRIMARY KEY, conversation_id TEXT, namespace TEXT, role TEXT, content TEXT,
+    source TEXT, created_at TEXT, seq INTEGER NOT NULL DEFAULT 0
+  )`);
+  memoriesSchema(sqlite);
+  sqlite.exec(`CREATE TABLE message_fts (fts_body TEXT, namespace TEXT, message_id TEXT)`);
+  sqlite.exec(`CREATE TABLE memory_fts (fts_body TEXT, namespace TEXT, memory_id TEXT)`);
+  const long = `${"前面铺垫。".repeat(40)}最后才出现月亮邮局暗号。`;
+  sqlite.prepare("INSERT INTO messages VALUES (?, ?, ?, ?, ?, ?, ?, ?)").run(
+    "msg_tail", "c", "ns", "user", long, "gw", "2026-09-06T12:00:00.000Z", 0
+  );
+  sqlite.prepare(`INSERT INTO memories (
+    id, namespace, type, content, summary, importance, confidence, status, pinned, tags,
+    source, source_message_ids, vector_id, created_at, updated_at
+  ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`).run(
+    "mem_tail", "ns", "note", long, null, 0.8, 0.8, "active", 0, "[]",
+    "extract", "[]", "v", "2026-09-01", "2026-09-01"
+  );
+
+  const db = wrapSqlite(sqlite);
+  const filled = await backfillFts(db as any, { namespace: "ns", limit: 50 });
+  assert.equal(filled.messagesIndexed, 1);
+  assert.equal(filled.memoriesIndexed, 1);
+  const messageBody = sqlite.prepare("SELECT fts_body FROM message_fts WHERE message_id = ?").get("msg_tail") as { fts_body: string };
+  const memoryBody = sqlite.prepare("SELECT fts_body FROM memory_fts WHERE memory_id = ?").get("mem_tail") as { fts_body: string };
+  assert.match(messageBody.fts_body, /暗号|邮局|月亮/);
+  assert.match(memoryBody.fts_body, /暗号|邮局|月亮/);
+  assert.match(toFtsBody(long), /暗号|邮局|月亮/);
+
+  sqlite.exec("DELETE FROM message_fts");
+  sqlite.exec("DELETE FROM memory_fts");
+  const rebuilt = await rebuildFts(db as any, { namespace: "ns", limit: 50 });
+  assert.equal(rebuilt.messagesIndexed, 1);
+  assert.equal(rebuilt.memoriesIndexed, 1);
+  assert.equal(sqlite.prepare("SELECT count(*) AS n FROM message_fts").get()!.n, 1);
+  sqlite.close();
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
对照 `16da748` 复现意见，按正确性 → 证据质量 → 运行闭环修，不改网关 BYOK 路由。

## 正确性

- **自动审核**：新增 / 更新 / 删除用不同判断规则。`dream_delete` 的高分不再表示“这条事实值得留着”，而是“这条记忆应该归档”。模型若仍按旧提示把有据、稳定的事实打高分，候选会被否决，目标记忆保留。
- **布尔解析**：`Boolean("false")` 已去掉。`"false"` / `"true"` 按字面解析；解析失败则整条评审作废，不会自动通过。
- **FTS SQL 参数**：`id IN (...)` 与 bind 数组顺序对齐。有全文命中时不再把 LIKE 参数绑进 ID 槽。补了“FTS 返回 2 个 ID 后仍能查出 2 行”的测试（本环境 node sqlite 无 FTS5，MATCH 用夹具模拟命中）。
- **问答顺序**：`messages.seq` 回合内序号；`gw_user_*` / `gw_req_*` 同时间戳时按提问再回答读取。哈希 ID 只负责唯一性。分页游标用 cursor 行的 `seq`，不再靠 ID 字典序。

## 证据质量

- **记住**：区分保存指令、追问、回忆问句。`记住了吗？`、`remember when we talked…` 不再入库。`只回复三个字：记住了` 这类格式要求会剥掉。写入 `note` + `verbatim`，不再升成高置信度亲笔 fact。事实提炼和版本替换仍交给 Dream。
- **原话截取**：围绕命中位置取 280 字，长消息末尾的暗号会进展示片段。
- **去重**：普通记忆与**展示摘录**去重，避免只剩一段截掉答案的引用。

## 运行闭环

- FTS 写入带重试；缺表/无 FTS5 时不连打错误日志。
- 创建 / 更新 / 归档 / 删除 / 过期 / 原文留存清理都会同步或清掉索引。
- `backfillFts` / `rebuildFts` 可从源文本重建；cron 维护会回填缺口。
- 索引 tokenizer 同时取文首和文尾，长消息末尾关键词能进索引。
- 检索按 `bm25` 排序（不支持时回退）。
- 召回解释日志带最终条目 ID、命中理由、排除原因。

## 验证

`npm run verify` 通过：gateway 27、recall 19、diary 4，加上原有 verify 脚本。

未改网关原生端点路由；CC / Codex 工具续轮和流式行为按你的计划明天用实际线路测。

关系记忆抢位置仍是统一预算，还不是统一相关性排序；这轮只把解释日志补到能逐条看。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0e291027-5beb-4cd7-a2f3-b43b58881237?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0e291027-5beb-4cd7-a2f3-b43b58881237&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

