### PR TITLE
把 README 写成三步上手，示例改成普通助手

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,200 +1,145 @@
 # Aelios
 
-> **`feat/memory-gateway` 开发分支**：主入口改为 Cloudflare 原生三协议记忆网关。
-> 请先看 [网关配置与接入](docs/memory-gateway.md)，配置入口：`/admin` 的「设置」页（网关卡片），或独立页 `/admin/gateway`。
-> 每个身份一个地址 `https://<host>/<身份>/v1`，模型名按 `provider/模型` 原样透传。
-> CF 上游的协议路由：chat 走 compat（全 provider，BYOK 生效）；messages 走 `…/{provider}/v1/messages`，responses 走 `…/{provider}/v1/responses`（openai 特例无 v1）——都走各 provider 原生端点，模型名自动剥前缀；模型列表走 compat 目录。
-> Worker Settings 只需要 `CHATBOX_API_KEY` + `CLOUDFLARE_API_TOKEN` 两把密钥，其余参数在面板的「环境设置」里填，下文的变量表仅供查阅。
-> 下文旧聊天接入说明仅供历史参考，本分支以新文档为准；旧记忆管理与 MCP 仍保留。
+给 AI 加一颗长期记忆。换窗口、换客户端、换模型，记忆跟着你走。
 
-> 给 AI 装一颗跨窗口的长期记忆大脑。换窗口、换客户端、换模型，记忆跟着你走。
+它是一个跑在 Cloudflare 上的记忆网关：你的 Chatbox / Claude Code / Codex 先连它，它再把请求转给模型。对话会被记下来，下次自动想起来。
 
-这份 README 分两段。**上半段给人看**：草履虫也能懂，照着做就能用。**下半段给 AI 看**：端点、MCP、管线细节，给 Codex / Claude Code / Cursor 维护调试用。
+## 怎么用
 
-- 我是人类，想部署使用 → 看 [人类版](#人类版)
-- 我是 AI 助手，想维护调试 → 看 [AI 版](#ai版维护交接)
-
-## 分支指路
-
-- **main**：唯一主线，作者线上跑的就是这套（v2 记忆系统：六层分层、三档写入、v4 assembler 缓存、boot 包 + 召回三闸）。AGPL-3.0。
-- **memory-v2 分支已退役**：内容已全部并入 main，不再更新，历史留档。老用户如果 Cloudflare 构建还指着 memory-v2，把 Production branch 切回 main 即可，数据不用迁。
-- **tg-bot**：Telegram bot 集成分支（TWIN-WORKER：部署独立 worker `aelios-tgbot`，共享同一 D1/Vectorize），叠在主线上。部署方式点这里：[docs/telegram-bot.md（tg-bot 分支）](https://github.com/wusaki0723/Aelios/blob/tg-bot/docs/telegram-bot.md)。
-
-## 想用 v1 最终版？
-
-```bash
-git clone https://github.com/wusaki0723/Aelios
-cd Aelios
-git checkout v1-final
-```
-
-v1-final 是 v1 稳定版的最终封存点，之后不再维护；注意 v1-final 里的许可证仍是 MIT（换证不溯及已发布的版本），想要轻量老版的用户可以继续按 MIT 使用，文档以该 tag 内的 README 为准。
-
----
-
-# 人类版
-
-## 一句话
-
-Aelios 是一个跑在 Cloudflare 上的记忆服务。你的 AI 客户端（Chatbox、Cherry Studio、网页、脚本）连上它之后，AI 就能**永远记住**你的偏好、规则、项目背景和重要的话——不是这一次记得，是下一次、下下次都记得。
-
-## 它替你解决了什么
-
-- 每次开新窗口 AI 就失忆 → 它把聊天存下来，自动整理成长期记忆，下次自动召回。
-- 记忆太多把 AI 搞蠢 → 它先粗筛、再精排，原文直出进上下文。
-- 换个客户端记忆就没了 → 记忆存在你自己的 Cloudflare 里，换客户端只改一个地址。
-- 想给 Claude Code / Codex 加记忆 → 它能当成 MCP 工具挂上去，跨设备随身。
-
-## 一键部署（推荐）
-
-[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/wusaki0723/Aelios)
-
-点按钮，登录 Cloudflare，它会替你做完所有事：把仓库复制到你的 GitHub、按配置建好 D1 / Vectorize / Queue、**在部署前弹表单让你把密钥一次填好**、接上 push 自动部署。
-
-表单里唯一必填的是 `CHATBOX_API_KEY`：自己编一个密码（比如 `sk-my-aelios`），以后客户端连 Aelios 就用它。其余全部可以留空，什么时候要用什么功能再回来补（见下文可选功能各节）。
-
-表单里其余几栏的标准答案：
-
-- **Vectorize 索引**：Dimensions 填 `1024`，Metric 选 `cosine`。嵌入模型 bge-m3 定死的值，照抄就行（这栏没法预填是 Cloudflare 表单自己的限制，已向上游反馈）。
-- **构建命令**（Build command）填 `npm ci`，**部署命令**（Deploy command）填 `npm run deploy`。
-
-部署完你会拿到一个地址：`https://companion-memory-proxy.<你的子域>.workers.dev`，直接跳到「[接客户端](#3-接客户端)」。
-
-## 手动部署（想自己掌控每一步）
+就三步。
 
 ### 1. 部署
 
-1. Fork [wusaki0723/Aelios](https://github.com/wusaki0723/Aelios) 到自己 GitHub。
-2. Cloudflare Dashboard → Workers & Pages → Create application → 连你的 GitHub → 选你的 fork。
-3. 填配置：
-   - Project name: `companion-memory-proxy`
-   - Production branch: `main`
-   - Root directory: `/`
-   - **Build command:** `npm ci`
-   - **Deploy command:** `npm run deploy`
+[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/wusaki0723/Aelios)
 
-> `npm run deploy` 会自动建好 D1 数据库 + Vectorize 向量库 + Queue 队列并应用建表迁移（老文档里的 `npm run deploy:cloudflare` 还在，是同一条命令的别名）。不要用裸 `wrangler deploy`，那样资源不会建。
+点按钮，登录 Cloudflare。表单里**只必填** `CHATBOX_API_KEY`：自己编一个密码，比如 `sk-my-aelios`。其余可以空着。
 
-不配任何模型 key、不配 AI Gateway，记忆召回和夜间 dream 也能跑（Workers AI 默认链路）。
+Vectorize 那栏照抄：Dimensions `1024`，Metric `cosine`。构建命令 `npm ci`，部署命令 `npm run deploy`。
 
-### 2. 设一把钥匙
+部署完会得到一个地址，类似：
 
-部署完，去 Worker 的 Settings → Variables and Secrets 加一个：
+```
+https://companion-memory-proxy.<你的子域>.workers.dev
+```
 
-| 变量名 | 类型 | 填什么 |
-|---|---|---|
-| `CHATBOX_API_KEY` | Secret | 自己编一个密码，比如 `sk-my-aelios` |
+想自己掌控每一步的话：Fork 本仓库 → Cloudflare Workers 连上 GitHub → 构建 `npm ci`、部署 `npm run deploy` → 在 Worker Settings 里加 Secret `CHATBOX_API_KEY`。不要用裸 `wrangler deploy`，那样不会建库。
 
-就这一个必填。`CLOUDFLARE_ACCOUNT_ID` 不用你填——部署时 setup 脚本从部署环境自动取了写进变量。`CLOUDFLARE_API_TOKEN` 只有用到「维护工具」（Vectorize 对账清理）时才需要，日常记、召、夜间整理都用不到，用到那天再补。
+### 2. 加一个助手
 
-> 名字里带 `KEY` / `TOKEN` 的必须选 **Secret**（加密、不进 git），不要选 Variable。详见 [SECRETS.md](./SECRETS.md)。完整密钥清单（哪些必填哪些可选）见 [.dev.vars.example](./.dev.vars.example)。
-
-保存后重新部署。你会拿到一个地址：`https://companion-memory-proxy.<你的子域>.workers.dev`
-
-### 3. 接客户端
-
-先在 `/admin` 的「设置」页（或 `/admin/gateway`）配好上游地址和至少一位身份（老公），然后按客户端选协议：
-
-| 客户端 | 地址 | 协议 |
-|---|---|---|
-| Chatbox 等 OpenAI 兼容客户端 | `https://<Worker 地址>/<身份>/v1` | chat/completions |
-| Claude Code | `ANTHROPIC_BASE_URL=https://<Worker 地址>/<身份>` | messages |
-| Codex | `base_url = https://<Worker 地址>/<身份>/v1`，并设 `wire_api = "responses"` | responses |
-
-**API Key** 都填你设的 `CHATBOX_API_KEY`。**Model** 按 `provider/模型` 写真名（如 `anthropic/claude-opus-5`、`openrouter/anthropic/claude-haiku-4.5`)，身份里登记的主模型才有记忆，其余模型安静透传。不带身份名的 `/v1` 走这把钥匙的第一位身份。
-
-身份可分别设置**写入空间**和多个**召回空间**，支持共享项目记忆、写新库继续读旧库；不填召回空间时沿用旧配置。
-请求会经过协议字段净化及 Anthropic 结构预检。thinking 默认透传时，未明确关闭思考就跳过临时注入；需要共存可选 `drop_block`，须上游支持 binding beta。
-配置和限制见 [记忆网关](docs/memory-gateway.md) 与 [请求契约 / thinking 审计](docs/request-contract.md)。
-
-试着说："请记住：我的测试暗号是苹果星星-0428。" 过一会儿问："我的测试暗号是什么？" 答出来就通了。
-
-## 管理面板（推荐用这个）
-
-有面板了，**日常管记忆不用敲命令**。浏览器打开：
+浏览器打开：
 
 ```
 https://<你的 Worker 地址>/admin
 ```
 
-填入 Worker URL 和 API Key，进去就是可视化界面，底部 5 个标签：
+填 Worker 地址和刚才那把钥匙，进「设置」。
+
+1. **上游地址**：填你的 Cloudflare 账号 ID（32 位）。要用完整聊天转发的话，再在 Worker Secrets 里加 `CLOUDFLARE_API_TOKEN`。
+2. **助手**：点「添加助手」，例如：
+
+   | 栏 | 填什么 | 例子 |
+   |---|---|---|
+   | 名字 | 地址里那一段，小写英文 | `coder` |
+   | 主模型 | 只有这些模型会记、会召回 | `anthropic/claude-opus-4-5` |
+   | 钥匙 | 谁能用这个助手 | 勾选主钥匙 |
+
+3. 点「保存」。
+
+一个助手一个地址。名字写成 `coder`，地址就是：
+
+```
+https://<你的 Worker 地址>/coder/v1
+```
+
+主模型才有记忆。没登记的模型（比如 Claude Code 里的小模型）只是路过，不记也不召。
+
+### 3. 客户端指过来
+
+API Key 一律填 `CHATBOX_API_KEY`。模型名写成 `厂商/模型`，比如 `anthropic/claude-opus-4-5`。
+
+| 你用什么 | 填这个地址 |
+|---|---|
+| Chatbox、Cherry Studio 等 | `https://<Worker 地址>/coder/v1` |
+| Claude Code | `ANTHROPIC_BASE_URL=https://<Worker 地址>/coder` |
+| Codex | `base_url = https://<Worker 地址>/coder/v1`，并设 `wire_api = "responses"` |
+
+不带助手名的 `/v1` 会走这把钥匙的第一个助手。
+
+试一句：「请记住：我的测试暗号是苹果星星-0428。」过一会儿再问：「我的测试暗号是什么？」答出来就通了。
+
+## 平时怎么管
+
+打开 `/admin`，底部几个标签：
 
 | 标签 | 干什么 |
 |---|---|
-| **今日** | 今天聊了什么、昨日日志、今日消息、记忆类型统计，一眼看完 |
-| **审核队列** | dream 夜间整理和抽取的稳定事实会到这里，你点**通过 / 丢弃 / 合并 / 取代**，不让垃圾记忆污染记忆库 |
-| **重要记忆** | 所有长期记忆，按类型分页浏览、搜索、编辑、删除 |
-| **更多** | 珍贵记忆（只增不删的原文）、黑话表（术语别名）、世界知识、维护工具 |
-| **设置** | 主题、地址、密钥 |
+| **今日** | 今天聊了什么 |
+| **审核队列** | 夜间整理出来的候选记忆，点通过或丢掉 |
+| **重要记忆** | 浏览、搜索、改、删 |
+| **更多** | 珍贵原文、术语表、维护工具 |
+| **设置** | 上游、助手、环境参数 |
 
-**想让 AI 记住什么、忘掉什么、改什么，都在面板点。** 不用调 API。
+想让 AI 记住、忘掉、改掉什么，在面板点就行。
 
-## 想要完整聊天网关（可选）
-
-只想要记忆库可以跳过这步。想让 Aelios 当三协议聊天网关（BYOK 计费走你自己的 provider key）:
-
-1. Cloudflare → AI → AI Gateway → 建一个 gateway;BYOK 的 provider key 存在它名下（Provider Keys / Custom Providers)。
-2. 回 Worker → Variables and Secrets 加一把 Secret:`CLOUDFLARE_API_TOKEN`(CF API token,AI Gateway 读写权限）。
-3. 打开 `/admin` 的「设置」页（或 `/admin/gateway`)，上游地址填 **32 位账号 ID**,Gateway ID 在「环境设置」里改（默认 `default`)，再加身份（老公）。
-
-协议路由网关自己分得清：chat 全 provider 走 compat;messages / responses 走各 provider 的原生端点。BYOK 全程生效——REST 面只花 Unified 额度，本设计不走它。
-
-## 给 Claude Code / Codex 加记忆（可选）
-
-不用新钥匙，直接在客户端的 MCP 配置里填：
+## 它实际在做什么
 
 ```
-URL:    https://<你的 Worker 地址>/mcp?token=<你的 CHATBOX_API_KEY>
+你的客户端  →  Aelios（认助手、记、召回）  →  模型
 ```
 
-你的官方客户端就有跨设备随身记忆了。
+- 你每说一句，相关旧记忆会贴到这次对话里。
+- 对话原文先存下来；夜里自动整理成长期记忆（Dream），重要的会进审核队列。
+- 记忆存在你自己的 Cloudflare（D1 + Vectorize），不绑某个聊天窗口。
 
-想给 MCP 一把独立钥匙的话，加一个 Secret `MEMORY_MCP_API_KEY` 换到 URL 里用。区别有两点：这把钥匙只有记忆读写权限（不能调聊天转发），且经它写入的记忆按「亲笔」记档（E 轴署名，夜间整理不会自动改写）。单人自用不折腾这个也完全没问题。
+一个助手可以写一个空间、读好几个空间。比如新对话写 `coder`，同时还能读旧库 `coder-old` 和共享的 `shared-docs`。不填召回空间就只读自己那个。
 
-如果你想让 Claude Code 每次发消息前自动召回长期记忆，并把对话批量写回 Aelios，可以使用仓库自带的 Claude Code Hook：
+## 可选功能
 
-- Hook 文件：[`integrations/claude-code/companion_memory_hook.py`](./integrations/claude-code/companion_memory_hook.py)
-- 安装说明：[`integrations/claude-code/README.md`](./integrations/claude-code/README.md)
-- 示例配置：[`integrations/claude-code/settings.example.json`](./integrations/claude-code/settings.example.json)
+**完整聊天网关**（想让 Aelios 转发各家模型，用你自己的 key 计费）
 
-Hook 只需要你的 Aelios Worker 地址和 `CHATBOX_API_KEY`，不需要任何 LLM provider key。
+1. Cloudflare → AI → AI Gateway，建一个 gateway，把各家 key 存在它下面。
+2. Worker Secrets 加 `CLOUDFLARE_API_TOKEN`。
+3. `/admin` 设置里，上游填 32 位账号 ID，再加助手。
 
-## 看图模式（可选）
+不配这些，记忆召回和夜间整理也能跑（走 Workers AI）。
 
-纯文本模型看不了图？加 `GUIDE_DOG_API_KEY`，客户端改成：
+**给 Claude Code / Codex 加 MCP 记忆**
 
-- **Base URL:** `https://<你的 Worker 地址>/v1/guide-dog`
-- **API Key:** `GUIDE_DOG_API_KEY`
-- **Model:** `companion`
+```
+https://<Worker 地址>/mcp?token=<CHATBOX_API_KEY>
+```
 
-导盲犬只转述图片，不写记忆、不存聊天。
+想让 Claude Code 每条消息自动召回、批量写回，用仓库里的 Hook：[`integrations/claude-code/`](./integrations/claude-code/README.md)。
 
-## 零配置也能用
+**看图**
 
-默认链路不需要 AI Gateway、不需要第三方模型 key：embedding + reranker + dream（每天一次）都跑 Workers AI。部署时填好 `CHATBOX_API_KEY` 一个就能记、能召、能夜间整理。
+加 Secret `GUIDE_DOG_API_KEY`，客户端改成：
 
-Workers AI 免费额度主要花在每日一次的 dream（默认 `gpt-oss-120b`）和偶尔的 reranker/embedding 上——**不再有每轮聊天的压缩模型**，额度压力小很多。真要换 `EMBEDDING_MODEL` 注意维度会变（需重建 Vectorize 索引，面板「更多 → 维护」里有工具）。
+- 地址：`https://<Worker 地址>/v1/guide-dog`
+- 模型：`companion`
+
+导盲犬只转述图片，不写记忆。
 
 ## 最容易踩的坑
 
-- 部署命令用 `npm run deploy`（或老名字 `npm run deploy:cloudflare`，同一条命令），裸 `wrangler deploy` 不建库。
-- 重新部署变量不会丢（命令带 `--keep-vars`）。
-- Vectorize 索引 `memo-kb`（1024 维 cosine）别手动删。
-- 看图会切到 `VISION_MODEL`，留意它的价格。
+- 部署用 `npm run deploy`，不要裸 `wrangler deploy`。
+- 助手名字是地址的一部分，用 `coder` 这种英文，别用空格。
+- 模型名要带厂商前缀：`anthropic/claude-opus-4-5`，不要只写 `claude-opus-4-5`。
+- 只有助手里登记的主模型才有记忆。小模型、杂务模型别写进去。
+- Vectorize 索引别手动删（`memo-kb`，1024 维 cosine）。
 
-到这儿就够了，剩下的交给 AI。
+## 想看细节
+
+- 网关怎么路由、怎么记、怎么召回：[docs/memory-gateway.md](docs/memory-gateway.md)
+- 请求会改什么、thinking 怎么处理：[docs/request-contract.md](docs/request-contract.md)
+- 哪些密钥必填：[SECRETS.md](./SECRETS.md)
+- 维护、端点、MCP 工具：下面这一段
 
 ---
 
-# AI 版（维护交接）
+# 给维护的人
 
-> 给 Codex / Claude Code / Cursor / Gemini CLI。本节是端点、MCP、记忆管线的精确描述，用于维护和调试。
-
-## 项目定位
-
-Cloudflare Workers 上的 OpenAI-compatible Memory Proxy。帮用户部署时：**只关联用户自己的 fork**，Secrets / Variables 都在用户自己的 Cloudflare 账号，不要关联 wusaki0723/Aelios。
-
-## 资源约定
+Cloudflare Workers 上的记忆网关。帮用户部署时只关联**用户自己的 fork**，Secrets 都在用户自己的账号。
 
 | 资源 | 值 |
 |---|---|
@@ -203,290 +148,64 @@ Cloudflare Workers 上的 OpenAI-compatible Memory Proxy。帮用户部署时：
 | Vectorize | `memo-kb`（1024 维 cosine） |
 | Queue | `companion-memory` |
 | Embedding | `workers-ai/@cf/baai/bge-m3` |
-| Dimensions | 1024（覆盖 `EMBEDDING_MODEL` 时输出维度需匹配） |
 
-记忆库默认走 **v2**（`MEMORY_LIFECYCLE_ENABLED` 隐式开启）：D1 是本体，Vectorize 是镜像。兼容/回退开关默认隐藏。
+入口：`/<助手>/v1/chat/completions`、`/<助手>/v1/messages`、`/<助手>/v1/responses`。不带助手名的 `/v1/...` 走该钥匙的第一个助手。
 
-## 三种模式边界
+CF 上游：chat 走 compat（全厂商，BYOK）；messages / responses 走各厂商原生端点。模型名原样透传，厂商认不出来由上游报错。自定义 OpenAI 兼容地址原样转发。
 
-| 模式 | 入口 | 做什么 | 不做什么 |
-|---|---|---|---|
-| 完整版 | `POST /v1/chat/completions` | 认证、模型路由、记忆召回/注入、消息存 D1、Queue 维护、D1 清理、Claude cache | — |
-| 纯记忆 MCP | `/mcp` | 暴露记忆工具 | 不代理聊天 |
-| 导盲犬 | `POST /v1/guide-dog/chat/completions` | 转发 + 看图 | 不写/不读记忆、不存聊天 |
+配置三层，都在 `/admin` 设置（或 `/admin/gateway`）：上游、助手、环境参数。优先级：面板保存的 > `GATEWAY_CONFIG` > 空配置。
 
-## 模型路由
-
-```
-model=companion            → CHAT_MODEL
-请求含 image               → VISION_MODEL
-anthropic/claude*          → Anthropic native (/anthropic/v1/messages)
-  ├─ 显式 cache_control 锚定稳定 system 前缀（persona_pinned / boot_stable / client_system 稳定段）
-  ├─ 多断点策略：system 锚 + tail 锚 + 长 history 的 bridge 锚，≤4 个标记
-  ├─ dynamic_memory_patch 后移到当前 user 块、不打 cache_control，绝不破坏缓存前缀
-  └─ rolling user cache 默认开，automatic cache 默认关
-custom-provider/claude-*   → Provider native (/custom-provider/messages)
-其他                       → OpenAI compat (/compat/chat/completions)
-workers-ai/@cf/...         → env.AI.run（不走 AI Gateway）
-```
-
-**缓存安全要点**：召回补丁（每轮都变）被从 system blocks 里剥离，作为无 `cache_control` 的文本块追加到当前 user turn 末尾，位于所有断点之后。历史轮的召回补丁已固化成稳定 history，落在 tail 断点之前，可正常命中缓存。`verify-cache-strategy.mjs` T14 校验断点数 ≤4。
-
-**OpenRouter + Claude 路由约束**：OpenRouter 调 Claude 必须在 AI Gateway 里以 **custom-provider** 方式加 key，不能走官方 provider 路径。官方路径按 Anthropic 原生格式发请求，与 OpenRouter 的 OpenAI 兼容格式冲突，会破坏缓存和格式。模型名走 `custom-provider/claude-*` → Provider native 分支。
-
-**Workers AI 额度**：v3 召回链路只有 embedding + reranker（每轮，用量小）+ dream（每日一次，默认 `gpt-oss-120b`），共享 Workers AI 免费额度。不再有 per-turn 压缩模型。换 `EMBEDDING_MODEL` 会改维度，需重建 Vectorize 索引。
-
-## REST 端点
+### 常用端点
 
 | 方法 | 路径 | 说明 |
 |---|---|---|
 | GET | `/health` | 健康检查 |
-| GET | `/admin` `/memory-admin` | 管理面板（HTML） |
+| GET | `/admin` | 管理面板 |
 | GET | `/v1/models` | 模型列表 |
-| POST | `/v1/chat/completions` | 聊天网关（完整版） |
-| POST | `/v1/guide-dog/chat/completions` | 导盲犬（无记忆） |
-| GET / POST | `/mcp` `/memory-mcp` | MCP 端点 |
-| GET / POST | `/v1/memories` `/v1/memory` | 记忆列表 / 新建（v2 必须带 `fact_key`，走 upsert） |
-| GET / PATCH / DELETE | `/v1/memories/:id` `/v1/memory/:id` | 单条记忆操作 |
-| POST | `/v1/search/memories` `/v1/memory/search` | 记忆搜索（reranker 后原文直出；`filter:false` 跳 reranker，`include_prompt:true` 拿可注入文本；**无**注入记账） |
-| POST | `/v1/memory/recall` | v2 动态召回（见下节）；hook 客户端应优先使用 |
-| POST | `/v1/ingest/messages` `/v1/messages/ingest` | 写入原始聊天（v2 只落 raw） |
-| GET | `/v1/memory_boot` | 冷启动包：印象梯（昨日 daily + 最近 weekly/monthly）+ precious + glossary + 今日消息 + 统计 |
-| GET | `/v1/diary?date=YYYY-MM-DD` | 读单日日记（`daily_log`）；无记录 404 |
-| GET | `/v1/diary/recent` | 今日+昨日日记（存在几条给几条） |
-| GET / POST / DELETE | `/v1/precious` `/v1/precious/:id` | 珍贵记忆（只增不删的原文） |
-| GET / POST / PATCH / DELETE | `/v1/glossary` `/v1/glossary/:id` | 黑话表（term + aliases + definition） |
-| GET | `/v1/candidates` | 候选审核队列列表（`status` 默认 pending） |
-| POST | `/v1/candidates/:id/approve` | 通过候选 → 落库；响应带 `action`（`created` / `superseded` / `upserted`） |
-| POST | `/v1/candidates/:id/discard` | 丢弃候选 |
-| POST | `/v1/candidates/:id/merge` | 合并到既有记忆（`target_id`） |
-| POST | `/v1/candidates/:id/supersede` | 取代既有记忆（`target_id`） |
-| GET / PUT / DELETE | `/v1/cache/:namespace/:key` | 缓存 CRUD |
-| GET | `/api/memories/export` | 记忆导出 |
-| GET | `/v1/debug/cache_health` | 缓存健康 |
-| GET | `/v1/debug/vector_health` | 向量库健康 |
-| POST | `/v1/debug/vector_reindex` | 向量重建 |
-| POST | `/admin/monthly-rollup` | 手触发月级 rollup（35 天前的 weekly_log → monthly_log） |
+| POST | `/<助手>/v1/chat/completions` | OpenAI 兼容聊天 |
+| POST | `/<助手>/v1/messages` | Anthropic messages |
+| POST | `/<助手>/v1/responses` | OpenAI responses |
+| GET / POST | `/mcp` | MCP 记忆工具 |
+| GET / POST | `/v1/memories` | 记忆列表 / 新建 |
+| POST | `/v1/memory/recall` | 动态召回（hook 优先用这个） |
+| POST | `/v1/search/memories` | 原始搜索（不记账） |
+| POST | `/v1/ingest/messages` | 写入原始聊天 |
+| GET | `/v1/memory_boot` | 冷启动包 |
+| GET | `/v1/diary` `/v1/diary/recent` | 日记 |
+| GET / POST / DELETE | `/v1/precious` `/v1/glossary` | 珍贵原文 / 术语表 |
+| GET / POST | `/v1/candidates` | 审核队列 |
 
-所有非 `/health` `/admin` 端点都要 `Authorization: Bearer <key>`：`/v1/models` 与网关接口按白名单老公钥匙鉴权，记忆接口按 scope（`memory:read` / `memory:write`）鉴权。
+非 `/health` `/admin` 都要 `Authorization: Bearer <key>`。网关按助手钥匙鉴权，记忆接口按 `memory:read` / `memory:write`。
 
-### POST `/v1/memory/recall`
+### MCP 工具
 
-与 `/v1/memory/search` 相同鉴权（`memory:read`）。JSON body：
+`memory_search` `memory_list` `memory_get` `memory_delete` `memory_ingest` `memory_boot` `memory_recall` `memory_upsert` `memory_supersede` `memory_archive` `memory_pin` `glossary_set` `diary_get` `memory_export`
 
-| 字段 | 说明 |
-|---|---|
-| `query` | 必填，当前轮用户文本 |
-| `namespace` | 可选，默认 profile namespace |
-| `k` / `top_k` | 可选，召回条数上限（默认 `MEMORY_TOP_K`，服务端钳 1–100） |
-| `min_score` | 可选，0–1 分数地板 |
-| `types` | 可选，记忆类型过滤 |
-| `include_prompt` | 可选，为 true 且有命中时返回可注入 `prompt` |
+### 记忆怎么走
 
-走 v2 `runRecall` 管线，含三道去重闸（珍贵不进召回池、与核心层指纹去重、近期注入 decay）并更新 `last_injected_at`；每轮 hook 客户端应优先用此端点而非 `/search`（后者为原始搜索，不做注入记账）。
+写入：助手直写 `memory_upsert`；夜里 cron（`10 20 * * *`）从当天对话抽事实 → 进审核队列，并写日记 / 周记 / 月记。
 
-## MCP 工具（`/mcp`）
+召回：最后一句用户话 → 向量搜索 + 词面 → 重排 → 原文贴到当前消息末尾。日记不自动注入。
 
-v2 暴露 14 个工具。`memory_create`、`digest_get`、`digest_set` 已废弃；日记用 `diary_get`。
+清理：消息约 7 天，过期记忆 180 天标记，失效记录再过 30 天硬删。
 
-| 工具 | 作用 | 关键参数 / 备注 |
-|---|---|---|
-| `memory_search` | 向量搜索长期记忆 | `query`；`min_score`（0–1，默认 0.15） |
-| `memory_list` | 列记忆 | `type` / `status` / `limit` / `cursor` |
-| `memory_export` | 导出记忆 | 返回全量 |
-| `memory_get` | 取单条 | `id` |
-| `memory_delete` | 软删 | `id` |
-| `memory_ingest` | 写入消息 + 触发维护 | v2 只落 raw |
-| `memory_boot` | 拉冷启动包 | 昨日日志 + precious + glossary |
-| `diary_get` | 读日记 | `date` 可选，缺省=今日+昨日 |
-| `memory_recall` | 召回并返回可注入文本 | 用于 MCP 客户端自己拼上下文 |
-| `memory_pin` | 写珍贵记忆 | 只增不删 |
-| `glossary_set` | 写黑话术语 | term / aliases / definition |
-| `memory_upsert` | v2 主写入（需 `fact_key`） | 撞键 → supersede / mark-seen |
-| `memory_supersede` | 显式取代 | `old_id` + 新内容 |
-| `memory_archive` | 归档 | `id` |
-## 记忆管线（v3）
-
-**写入：**
-
-```
-agent 直写：memory_upsert / memory_supersede（MCP 或 REST）→ 直接落库
-dream 夜间（cron `10 20 * * *`）：
-  ├─ 从当天 raw messages 抽稳定事实 → 全部进 candidates（status=pending）
-  ├─ 合并/更新/删除建议 → 同样进 candidates（world_fact supersede 除外，直接落库）
-  │   └─ dream_update 候选继承目标记忆的 fact_key（不再硬编码 null）
-  ├─ 入队前 dedup gate 提示：向量相似命中且尚无 target → 写入 target_memory_id（不拦截）
-  ├─ 重要原文摘录 → candidates
-  ├─ 写 daily_log（title + summary）
-  ├─ weekly rollup（daily_log → weekly_log）
-  └─ monthly rollup（35 天前的 weekly_log 按月合并；同月 ≥2 周才卷，孤儿周等下月或并入已有 monthly）
-```
-
-候选 approve（面板或 `POST /v1/candidates/:id/approve`）：
-  ├─ `target_memory_id` 指向活跃记忆 → 直接 supersede
-  ├─ target 已失效 → 回落写入查重闸
-  ├─ 有 fact_key → upsert
-  ├─ 无 fact_key + `DEDUP_COSINE` 命中 → supersede（向量异常 fail-open，走 create）
-  └─ 响应带 `action`：`created` / `superseded` / `upserted`
-
-**印象梯（boot 稳定前缀）：** `[Impressions]` = 昨日 daily_log + 最近 weekly_log + 最近 monthly_log，预算 `IMPRESSION_LADDER_MAX_CHARS`（默认 1000），超出从月级往上截。不走召回通道。
-
-**隔离不变量：** daily_log / weekly_log / monthly_log 永不 embed、永不进 `/v1/memory/search` 与 `runRecall`。
-
-**召回（聊天前 / memory_recall）：**
-
-```
-取最后一条 user 消息 → embedding → Vectorize 搜索
-→ 分数地板 → 去重 → reranker 重排 → 记忆原文直出（默认 k=3, min_score=0.15）
-→ dynamic_memory_patch 追加到当前 user turn（不打 cache_control）
-```
-
-**日记：** `GET /v1/diary` 或 MCP `diary_get`——agent 自己 fetch，**永不自动注入**。
-
-### GitHub daily source
-
-cmh-lite 客户端每天 23:50（本地时区）会把 `archive/daily/YYYY-MM-DD.md` push 到 GitHub 私库。Aelios 在现有 cron（`10 20 * * *` UTC = 04:10 SGT，晚于 push 约 4 小时）里顺带拉取**昨天**的 daily 文件，解析 turn 行与 checkpoint writer 摘要，走与 `/v1/ingest/messages` 相同的 `saveIngestMessages` 管道入库，供夜间 dream 整理。
-
-| 变量 | 默认 | 说明 |
-|---|---|---|
-| `GITHUB_DAILY_REPO` | 空（禁用） | `owner/repo` 格式 |
-| `GITHUB_DAILY_PATH` | `archive/daily` | 仓库内目录 |
-| `GITHUB_DAILY_NAMESPACE` | `DREAM_NAMESPACE` 或 `default` | 入库 namespace |
-| `GITHUB_DAILY_TOKEN` | Secret | fine-grained PAT，**只读**目标仓库 Contents |
-
-客户端怎么产出这些 daily 文件：用 [memory-template](https://github.com/wusaki0723/memory-template) 建你的私有 vault 仓库——它内建 cmh-lite hooks（压缩前 checkpoint、开场注回、每晚自动 commit/push `archive/daily/`）。把 Worker 的 `GITHUB_DAILY_REPO` 指到那个私库，链路就通了。
-
-**清理（后台 Queue，24h 节流）：**
-
-```
-messages: 7 天删（可用 `MESSAGES_RETENTION_DAYS` 配置）
-usage_logs: 30 天删
-memory_events: 30 天删
-idempotency_keys: 7 天删
-memories: 非 pinned/identity/persona 180 天标 expired → 同步删 Vectorize
-hard delete: deleted/superseded/expired 超 30 天 → 先删 Vectorize 再删 D1
-（Vectorize 失败不删 D1，避免失配）
-```
-
-## 环境变量速查
-
-### 最小必填
-
-| 变量 | 说明 |
-|---|---|
-| `CHATBOX_API_KEY` | 客户端 + 面板访问密钥（Secret） |
-
-`CLOUDFLARE_ACCOUNT_ID` 部署时由 setup 脚本自动写入；`CLOUDFLARE_API_TOKEN`（Secret）仅维护工具/网关模式 Workers AI 转发需要，均不在必填之列。
-
-### 完整网关加填
-
-| 变量 | 说明 |
-|---|---|
-| `AI_GATEWAY_BASE_URL` | AI Gateway Endpoint |
-| `CF_AIG_TOKEN` | AI Gateway 调用 token |
-
-### 模型（都有默认）
-
-| 变量 | 默认 | 说明 |
-|---|---|---|
-| `CHAT_MODEL` | `deepseek/deepseek-v4-pro` | 主聊天 |
-| `DREAM_MODEL` | `workers-ai/@cf/openai/gpt-oss-120b` | 夜间 dream（抽取+整理） |
-| `VISION_MODEL` | `workers-ai/@cf/google/gemma-4-26b-a4b-it` | 看图 |
-| `EMBEDDING_MODEL` | `workers-ai/@cf/baai/bge-m3` | 嵌入 |
-| `EMBEDDING_DIMENSIONS` | `1024` | 非 Workers AI embedding 目标维度 |
-| `MEMORY_RERANKER_MODEL` | `workers-ai/@cf/baai/bge-reranker-base` | reranker |
-| `ENABLE_MEMORY_RERANKER` | `true` | `false` 跳过 |
-
-### 记忆召回 / dream
-
-| 变量 | 默认 | 说明 |
-|---|---|---|
-| `DEDUP_COSINE` | `0.9` | embedding 判重阈值（judge + 写入查重闸 approve） |
-| `IMPRESSION_LADDER_MAX_CHARS` | `1000` | boot 印象梯字符预算 |
-| `MEMORY_FILTER_MAX_CANDIDATES` | `12` | 进 reranker 候选上限 |
-| `MEMORY_FILTER_MAX_OUTPUT` | `3` | 注入条数（代理默认 k） |
-| `MEMORY_FILTER_MIN_SCORE` | `0.1` | 进 reranker 前地板（故意低） |
-| `RECALL_MIN_SCORE` | `0.15` | 召回分数地板 |
-| `DREAM_TIME_ZONE` | `Asia/Singapore` | 按此时区切自然日 |
-| `DREAM_MAX_MESSAGES` | `40` | 每次 dream 最多消息数 |
-| `DREAM_MAX_RUNS` | `10` | 每次 cron 最多 dream 批数 |
-| `DREAM_MAX_TOKENS` | `8000` | dream 输出上限 |
-| `DREAM_MEMORY_CONTEXT_LIMIT` | `40` | dream 参考旧记忆数 |
-| `GITHUB_DAILY_REPO` | 空 | GitHub daily 源仓库，`owner/repo`；空 = 禁用 |
-| `GITHUB_DAILY_PATH` | `archive/daily` | daily markdown 目录 |
-| `GITHUB_DAILY_NAMESPACE` | 空 | 入库 namespace，默认跟 `DREAM_NAMESPACE` |
-| `GITHUB_DAILY_TOKEN` | Secret | fine-grained PAT，只读目标仓库 Contents |
-
-### Claude 缓存
-
-> **本分支已移除。** 命中缓存与 thinking 编排随旧 assembler 一起退出，`ANTHROPIC_CACHE_*`
-> `ANTHROPIC_THINKING_*` `CUSTOM_ANTHROPIC_MESSAGES_PATH` 已从 wrangler.toml 删除、代码不再读取。
-> 现在 prompt cache 由客户端自己做，thinking 策略在 `/admin/gateway` 按身份配置。下表仅供历史参考。
-
-| 变量 | 默认 | 说明 |
-|---|---|---|
-| `ANTHROPIC_CACHE_ENABLED` | `true` | prompt cache 开关 |
-| `ANTHROPIC_CACHE_TTL` | `5m` | `5m` / `1h` |
-| `ANTHROPIC_AUTO_CACHE_ENABLED` | `true` | 顶层 automatic cache |
-| `ANTHROPIC_ROLLING_CACHE_ENABLED` | `true` | 滚动打点 |
-| `ANTHROPIC_ROLLING_CACHE_WINDOW_SIZE` | `20` | 历史窗口 |
-| `ANTHROPIC_CACHE_USER_ID` | 空 | 多客户端 cache 隔离用 `metadata.user_id` |
-| `ANTHROPIC_THINKING_ENABLED` | `false` | 深度思考 |
-| `ANTHROPIC_THINKING_BUDGET` | `1024` | 思考 token（1024–32000） |
-| `CUSTOM_ANTHROPIC_MESSAGES_PATH` | `messages` | 原生 messages 路径 |
-
-### 高级
-
-| 变量 | 默认 | 说明 |
-|---|---|---|
-| `MEMORY_TOP_K` | `50` | 向量粗召回条数 |
-| `MEMORY_MIN_SCORE` | `0.1` | 召回地板（故意低，精排交给 reranker） |
-| `MEMORY_FILTER_MAX_CONTENT_CHARS` | `700` | 候选每条保留字数 |
-| `VECTORIZE_INDEX_NAME` | `memo-kb` | Vectorize 索引名 |
-| `ENABLE_AUTO_MEMORY` | 空（开启） | `false` 关自动记忆 |
-| `EMPTY_MEMORY_MIN_CHARS` | `4` | 清短空记忆阈值 |
-| `PUBLIC_MODEL_NAME` | `companion` | 客户端看到的模型名 |
-| `IM_API_KEY` | 空 | 第二把钥匙（IM bot） |
-| `DEBUG_API_KEY` | 空 | 调试接口钥匙 |
-| `MEMORY_MCP_API_KEY` | 空 | 纯记忆 MCP 单独钥匙 |
-| `GUIDE_DOG_API_KEY` | 空 | 导盲犬单独钥匙 |
-
-## 本地开发与验证
+### 本地验证
 
 ```bash
 npm install
-npm run deploy              # 建库 + 升级 + 部署（deploy:cloudflare 是它的旧别名）
-npm run worker:test         # 主测试套件（177 项）
-node scripts/verify-extract-pipeline.mjs   # 4h 抽取管线行为测试
-node scripts/verify-cache-strategy.mjs     # Claude 缓存断点策略（15 项）
-npx tsc --noEmit            # 类型检查
+npm run verify
 ```
 
-改记忆 / 缓存 / 抽取相关代码后，至少跑后三个脚本。
-
-## 记忆库清洗
-
-旧 Vectorize 里长块、多主题块、重复总结多时，可让 LLM 先生成清洗计划：
-
-```bash
-AELIOS_BASE_URL="https://<worker>" \
-AELIOS_API_KEY="<CHATBOX_API_KEY>" \
-AI_GATEWAY_BASE_URL="<AI Gateway Endpoint>" \
-CF_AIG_TOKEN="<AI Gateway Token>" \
-CLEANUP_MODEL="deepseek/deepseek-v4-flash" \
-npm run vectorize:clean:llm
-```
-
-## 致谢
-
-- 关系图 + 2-hop 联想召回、`fact_key` 事实版本化、perception 自发浮现这三个设计，参考自 [LMC-5（Living Memory Coordinate-5）](https://github.com/wuxuyun0606-collab/lmc-5) 的 Y/Z 轴与 spontaneous recall 模型。LMC-5 是 PostgreSQL/pgvector 参考实现，Aelios 按 CF Worker + D1 + Vectorize 的形状重写了这三样，只抄了模型没抄代码——但思路是人家的，谢谢。
+测试需要 Node.js 22+。
 
 ## License
 
 AGPL-3.0
 
-可自由使用、修改本软件；但若你将修改后的版本对外提供网络服务，须以相同许可开源修改后的源码。
+可自由使用、修改；若把修改后的版本对外提供网络服务，须以相同许可开源修改后的源码。
 
-## 交流与反馈
+v1 最终封存点在 tag `v1-final`（当时仍是 MIT）。`tg-bot` 是 Telegram 集成分支。
 
-有问题、想交流，欢迎来 QQ 群：**1091783659**
+## 交流
+
+QQ 群：**1091783659**

--- a/docs/memory-gateway.md
+++ b/docs/memory-gateway.md
@@ -25,7 +25,7 @@ Aelios 负责身份、临时召回和自动记录，客户端 Harness 负责工�
 配置只有三层，全部在 `/admin/gateway` 页面完成：
 
 1. **连接**：CF 账号 ID（或完整地址）。token 不放面板，放 Worker Secret `CLOUDFLARE_API_TOKEN`。
-2. **身份（老公）**：每位三格——名字（slug，即 URL 路径段）、主模型列表、可用钥匙。
+2. **助手**：每位三格——名字（slug，即 URL 路径段）、主模型列表、可用钥匙。
    写入空间 `namespace` 默认同名；可另设 `readNamespaces` 召回空间列表。
 3. **环境设置**：`settings` 白名单里的运行参数，面板直接改，覆盖部署默认值。
 
@@ -46,16 +46,16 @@ Aelios 负责身份、临时召回和自动记录，客户端 Harness 负责工�
 2. 按原部署流程创建 D1、Vectorize 和 Queue，应用全部 migrations，包含 `0012_memory_gateway.sql`。
 3. Worker Secrets 只放两把钥匙：`CHATBOX_API_KEY`（自己编的，进面板用）和 `CLOUDFLARE_API_TOKEN`
    （使用现有 AI Gateway token 权限配置；第三方 Provider 密钥在 CF BYOK 面板管理）。
-4. 打开 `/admin/gateway`，填 CF 账号 ID，添加身份，保存。
-5. 客户端按身份接入：
+4. 打开 `/admin/gateway`，填 CF 账号 ID，添加助手（比如 `coder`），保存。
+5. 客户端按助手接入：
 
 | 客户端 | 配置 |
 | --- | --- |
-| Chatbox 等 OpenAI 兼容 | base URL `https://<host>/<身份>/v1`，填 `CHATBOX_API_KEY` |
-| Claude Code | `ANTHROPIC_BASE_URL=https://<host>/<身份>`，token 同上 |
-| Codex | `base_url = "https://<host>/<身份>/v1"`，`wire_api = "responses"` |
+| Chatbox 等 OpenAI 兼容 | base URL `https://<host>/coder/v1`，填 `CHATBOX_API_KEY` |
+| Claude Code | `ANTHROPIC_BASE_URL=https://<host>/coder`，token 同上 |
+| Codex | `base_url = "https://<host>/coder/v1"`，`wire_api = "responses"` |
 
-不带身份的 `/v1/...` 走该钥匙的第一个身份，方便单身份使用。
+不带助手名的 `/v1/...` 走该钥匙的第一个助手，方便只配一个的时候用。
 轮询和多 key 池需要时自行部署 new-api 之类的上游，把它的地址填进「连接」即可——配置模型不变。
 
 ## 临时记忆生命周期
@@ -82,19 +82,19 @@ Aelios 负责身份、临时召回和自动记录，客户端 Harness 负责工�
 
 ```json
 {
-  "slug": "danjiu",
+  "slug": "coder",
   "keys": ["CHATBOX_API_KEY"],
-  "models": ["*opus*", "*fable*"],
-  "namespace": "danjiu-new",
-  "readNamespaces": ["danjiu-new", "danjiu-old", "shared-project"]
+  "models": ["*opus*", "*sonnet*"],
+  "namespace": "coder",
+  "readNamespaces": ["coder", "coder-old", "shared-docs"]
 }
 ```
 
-多个身份可以读同一空间，也可写同一空间。迁移时让新对话写新空间，召回保留旧空间；这里不搬移 D1 行或 Vectorize 索引。
+多个助手可以读同一空间，也可写同一空间。迁移时让新对话写新空间，召回保留旧空间；这里不搬移 D1 行或 Vectorize 索引。
 每个空间独立检索，同类候选轮流合并、同类型同内容去重，最后统一执行一次条数/字数预算。
 一个空间失败仍可用其他空间，全部失败报告召回不可用；trace 列出失败空间。
 注入计数回写条目所属空间，`recall_explain` 存在写入空间，记录每条来源空间。
-授权某身份读取共享空间，意味着该身份的所有可用钥匙都可召回其内容。
+授权某助手读取共享空间，意味着该助手的所有可用钥匙都可召回其内容。
 Cron 继续维护配置的写入空间，避免只读共享关系无意触发另一个空间的 Dream。
 
 ### Anthropic thinking

--- a/src/api/admin/ui.ts
+++ b/src/api/admin/ui.ts
@@ -975,14 +975,14 @@ document.documentElement.dataset.theme = localStorage.getItem('aelios.admin.colo
           <input x-model="gwAddress" class="mt-2 h-11 w-full rounded-2xl border border-zinc-800 bg-[#0a0a0b] px-3 text-sm text-zinc-100 outline-none transition duration-150 ease-in-out focus:border-coral" placeholder="CF 账号 ID(32 位),或完整地址,如 new-api 的 https://…/v1">
           <p class="mt-1 text-[11px] leading-5 text-zinc-500">chat 走 compat,全 provider;messages / responses 走各 provider 原生端点,模型名带 provider/ 前缀;模型列表走 compat 目录。BYOK 钥匙在 AI Gateway 仪表盘;CF 令牌去 Worker Secrets 加 CLOUDFLARE_API_TOKEN。Gateway ID 在下方环境设置里,默认 default。</p>
           <div class="mt-4 flex items-center justify-between">
-            <label class="text-xs text-zinc-400">老公们</label>
-            <button type="button" @click="gwAdd()" class="tap rounded-2xl border border-zinc-800 px-3 py-1.5 text-xs text-zinc-400 transition duration-150 ease-in-out hover:border-coral hover:text-zinc-100">+ 添加一位</button>
+            <label class="text-xs text-zinc-400">助手</label>
+            <button type="button" @click="gwAdd()" class="tap rounded-2xl border border-zinc-800 px-3 py-1.5 text-xs text-zinc-400 transition duration-150 ease-in-out hover:border-coral hover:text-zinc-100">+ 添加助手</button>
           </div>
           <p class="mt-1 text-[11px] text-zinc-500">名字即地址路径段;主模型支持 * 通配,只有主模型有记忆、进 Dream。</p>
           <template x-for="(idn, i) in gwIdentities" :key="i">
             <div class="mt-2 space-y-2 rounded-2xl border border-zinc-800 bg-[#0a0a0b] p-3">
               <div class="flex items-center gap-2">
-                <input x-model="idn.slug" class="h-10 min-w-0 flex-1 rounded-xl border border-zinc-800 bg-zinc-900 px-3 text-sm text-zinc-100 outline-none focus:border-coral" placeholder="名字,如 danjiu">
+                <input x-model="idn.slug" class="h-10 min-w-0 flex-1 rounded-xl border border-zinc-800 bg-zinc-900 px-3 text-sm text-zinc-100 outline-none focus:border-coral" placeholder="名字,如 coder">
                 <button type="button" @click="gwIdentities.splice(i, 1)" class="tap shrink-0 rounded-xl border border-zinc-800 px-3 py-2 text-xs text-zinc-500 transition hover:border-coral hover:text-zinc-100">移除</button>
               </div>
               <input x-model="idn.modelsText" class="h-10 w-full rounded-xl border border-zinc-800 bg-zinc-900 px-3 text-sm text-zinc-100 outline-none focus:border-coral" placeholder="主模型,逗号分隔,如 anthropic/claude-opus-5, *fable*">
@@ -1006,7 +1006,7 @@ document.documentElement.dataset.theme = localStorage.getItem('aelios.admin.colo
               </details>
             </div>
           </template>
-          <div x-show="!gwIdentities.length" class="mt-2 text-xs text-zinc-500">还没有老公。点「读取」拉取线上配置,或直接添加。</div>
+          <div x-show="!gwIdentities.length" class="mt-2 text-xs text-zinc-500">还没有助手。点「读取」拉取线上配置,或直接添加。</div>
           <template x-if="gwGroups.length">
             <div class="mt-4">
               <label class="text-xs text-zinc-400">环境设置</label>
@@ -1253,7 +1253,7 @@ function memoryAdmin() {
           config.settings = settings;
         }
         const result = await this.request('/api/gateway/config', { method: 'PUT', body: JSON.stringify(config) });
-        this.notify('保存好了,' + (result.identities || 0) + ' 位在岗,环境设置最长 10 秒全网生效');
+        this.notify('保存好了,' + (result.identities || 0) + ' 个助手,环境设置最长 10 秒全网生效');
       } catch (error) { this.notify('网关保存失败:' + error.message); }
       this.gwBusy = false;
     },

--- a/src/gateway/admin.ts
+++ b/src/gateway/admin.ts
@@ -62,7 +62,7 @@ details{margin-top:8px}summary{cursor:pointer;color:#a6b4c3}
 .row{display:flex;gap:12px;flex-wrap:wrap;margin-top:14px}
 </style><body>
 <small>AELIOS / MEMORY GATEWAY</small><h1>带着记忆，随处接入。</h1>
-<p>一个老公一个地址，模型名原样透传。只有主模型有记忆、进 Dream，其余模型安静路过。<a href="/admin">记忆管理 →</a></p>
+<p>一个助手一个地址，模型名原样透传。只有主模型有记忆、进 Dream，其余模型安静路过。<a href="/admin">记忆管理 →</a></p>
 
 <section><label>管理钥匙（Worker 设置里的 CHATBOX_API_KEY，只留在本页）<input id="key" type="password" autocomplete="off"></label>
 <div class="row"><button id="load">读取</button><button id="save">保存</button></div><div id="status" role="status" aria-live="polite"></div></section>
@@ -70,8 +70,8 @@ details{margin-top:8px}summary{cursor:pointer;color:#a6b4c3}
 <section><h2>上游连接</h2>
 <label>上游地址<input id="cfAddress" placeholder="CF 账号 ID(32 位),或完整地址,如 new-api 的 https://…/v1"><div class="hint">最省心:填 32 位账号 ID,贴 Cloudflare 网关网址也能认。chat 走 compat,全 provider;messages / responses 走各 provider 的原生端点,模型名记得带 <code>provider/模型</code> 前缀;模型列表走 <code>…/compat/models</code>。BYOK 全程生效,provider 钥匙在 AI Gateway 仪表盘里存。Gateway ID 在下面环境设置里,默认 <code>default</code>。填别的 OpenAI 兼容地址(如 new-api)就原样用。令牌去 Worker Secrets 加 <code>CLOUDFLARE_API_TOKEN</code>。</div></label></section>
 
-<section><h2>老公们</h2><p class="hint">每位三格：名字、主模型、钥匙。主模型支持 <code>*</code> 通配，写不写 <code>anthropic/</code> 前缀都能认。</p>
-<div id="identities"></div><button id="addIdentity" class="ghost">+ 添加一位</button></section>
+<section><h2>助手</h2><p class="hint">每位三格：名字、主模型、钥匙。主模型支持 <code>*</code> 通配，写不写 <code>anthropic/</code> 前缀都能认。</p>
+<div id="identities"></div><button id="addIdentity" class="ghost">+ 添加助手</button></section>
 
 <section><h2>环境设置</h2><p class="hint">每格留空就是用默认值，灰字是当前生效的值。点「读取」后出现。</p><div id="settings"></div>
 <h3>钥匙状态</h3><p class="hint">钥匙都在 Worker 设置里，这里只看在不在。</p><div id="secrets"></div></section>
@@ -88,8 +88,8 @@ function h(tag,attrs,...kids){const n=document.createElement(tag);for(const k in
 function field(labelText,hintText,value,placeholder){const input=h('input',{value:value||'',placeholder:placeholder||''});const label=h('label',{text:labelText});label.append(input);if(hintText)label.append(h('div',{class:'hint',text:hintText}));return{label,input}}
 function addCard(data){
   data=data||{};
-  const slug=field('名字','就是地址里那一段，比如 danjiu。小号英文，别用空格。',data.slug,'danjiu');
-  const models=field('主模型（逗号分隔，可多选）','只有主模型的对话召回记忆、进 Dream；其余模型在这位名下安静透传。',(data.models||[]).join(', '),'anthropic/claude-opus-4-5, *fable*');
+  const slug=field('名字','就是地址里那一段，比如 coder。小号英文，别用空格。',data.slug,'coder');
+  const models=field('主模型（逗号分隔，可多选）','只有主模型的对话召回记忆、进 Dream；其余模型在这个助手名下安静透传。',(data.models||[]).join(', '),'anthropic/claude-opus-4-5, *sonnet*');
   const ns=field('写入空间','新对话写到这里，留空就和名字同名。',data.namespace,'');
   const reads=field('召回空间（逗号分隔）','留空只读写入空间；填写多个空间可共享、保留旧库；填 [] 只记录不召回。',data.readNamespaces ? (data.readNamespaces.length ? data.readNamespaces.join(', ') : '[]') : '', '');
   const keysBox=h('div',{class:'keys'});
@@ -98,10 +98,10 @@ function addCard(data){
   const thinking=field('Claude 思考块','passthrough 保留思考，未明确关闭思考时跳过注入；drop_block 允许临时记忆，需上游支持 beta，失配的思考由上游丢弃。',data.anthropicThinking||'passthrough','');
   const budget=field('单次记忆字数上限','留空默认 6000。',data.maxMemoryChars||'','');
   const del=h('button',{class:'danger',text:'移除'});del.onclick=()=>card.remove();
-  const title=h('h3',{text:data.slug||'新老公'},del);
-  slug.input.addEventListener('input',()=>{title.firstChild.textContent=slug.input.value.trim()||'新老公'});
+  const title=h('h3',{text:data.slug||'新助手'},del);
+  slug.input.addEventListener('input',()=>{title.firstChild.textContent=slug.input.value.trim()||'新助手'});
   const advanced=h('details');advanced.append(h('summary',{text:'高级'}),thinking.label,budget.label);
-  const card=h('div',{class:'card'},title,slug.label,models.label,ns.label,reads.label,h('label',{text:'谁能用这位'}),keysBox,advanced);
+  const card=h('div',{class:'card'},title,slug.label,models.label,ns.label,reads.label,h('label',{text:'谁能用这个助手'}),keysBox,advanced);
   card.collect=()=>{
     const keys=boxes.filter(b=>b.input.checked).map(b=>b.name);
     const identity={slug:slug.input.value.trim(),keys,models:models.input.value.split(/[,，\\n]/).map(s=>s.trim()).filter(Boolean)};
@@ -141,6 +141,6 @@ async function request(method,body){
 el('load').onclick=async()=>{try{const config=await request('GET');render(config);
   const r=await fetch('/api/gateway/env',{headers:{authorization:'Bearer '+el('key').value}});renderEnv(await r.json());settingsLoaded=true;
   status('读好了。')}catch(e){status(e.message)}};
-el('save').onclick=async()=>{try{const data=await request('PUT',collect());status('保存好了，'+data.identities+' 位在岗。环境设置最长 10 秒全网生效。')}catch(e){status(e.message)}};
+el('save').onclick=async()=>{try{const data=await request('PUT',collect());status('保存好了，'+data.identities+' 个助手。环境设置最长 10 秒全网生效。')}catch(e){status(e.message)}};
 el('addIdentity').onclick=()=>addCard();
 </script></body></html>`;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 这个 fork 现在在做什么

`feat/memory-gateway` 已经不是「聊天代理 + 一堆历史文档」了，主路径很短：

1. 部署 Worker，设一把 `CHATBOX_API_KEY`
2. 在 `/admin` 加一个助手（名字、主模型、钥匙）
3. 客户端指到 `https://<worker>/<助手>/v1`

只有助手里登记的主模型会记、会召回、会进夜间 Dream。没登记的模型安静路过。记忆存在用户自己的 D1 / Vectorize。

实现本身没问题，难的是文档：旧 README 把协议路由、BYOK、历史分支、已删除的 Claude 缓存表全堆在开头，人跟着做会迷路。面板和文档里的「老公们 / danjiu」也太具体，不像通用 agent 示例。

## 这次改了什么

- **README**：按现有实现重写成「部署 → 加助手 → 指客户端」。维护用的端点表收到文末，细节指向 `docs/memory-gateway.md`。
- **示例**：`danjiu` → `coder`；「老公们」→「助手」。面板、独立网关页、网关文档一起改了。
- 星图里的彩蛋（旦九）没动，那不是给别人抄的配置示例。

## 怎么跟做（现在的 README）

部署 → 打开 `/admin` → 加助手 `coder`，主模型写 `anthropic/claude-opus-4-5` → 客户端填 `https://<worker>/coder/v1`。API Key 就是那把 `CHATBOX_API_KEY`。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f3b21521-2a1c-44f1-a5d2-9ba0f85e55d3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f3b21521-2a1c-44f1-a5d2-9ba0f85e55d3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

