### PR TITLE
feat(gateway): thinking 直通恢复记忆注入(带 Vertex 实测证据)

### DIFF
--- a/docs/memory-gateway.md
+++ b/docs/memory-gateway.md
@@ -99,12 +99,13 @@ Cron 继续维护配置的写入空间，避免只读共享关系无意触发另
 
 ### Anthropic thinking
 
-- `passthrough`（默认）：不修改 thinking。未明确关闭思考时跳过注入，响应头为 `x-aelios-memory: skipped-thinking`。
-  末尾追加不影响此前 thinking，但会成为**本次新生成 thinking** 的前缀；下轮撤销补丁可能导致签名失配。
+- `passthrough`（默认）：不修改 thinking，记忆照常注入。召回片段只追加在最后一轮 user 消息尾部，
+  不改历史块。实测 Vertex 线路默认不校验 thinking 的前缀绑定(补丁下轮消失,旧签名块仍 200),
+  只有客户端显式携带 `block_binding` 时前缀才进入签名范围。
 - `drop_block`：在每次请求（含工具续轮）合并 `thinking.block_binding.prefix_mismatch_behavior: "drop_block"`，
   以及 `thinking-binding-controls-2026-08-01` beta header。仅适用于支持该 beta 的线路，会牺牲部分思考连续性。
 - 显式 `thinking.type: "disabled"`：直接临时注入，不添加该 beta。
-- 客户端自己携带合法的 `drop_block` 和对应 beta 时，透传模式也允许注入。
+- 注意:`drop_block` 依赖上游认识 `block_binding` 字段;Vertex 线路会直接 400 `unrecognizedProperty`,勿用于 Vertex。
 - 非主模型不自动启用 thinking，不自动添加 binding 设置。
 
 本地只能验证结构，不能验证厂商的加密签名。历史签名块、空 thinking 文本、redacted data 原样保留。

--- a/docs/request-contract.md
+++ b/docs/request-contract.md
@@ -27,7 +27,7 @@
 
 | 情形 | 召回/注入 | 思考历史及出站策略 |
 | --- | --- | --- |
-| 主模型、人类输入、默认 passthrough，thinking 开启或未指定 | 跳过，`skipped-thinking` | 历史不变，不主动生成临时前缀绑定 |
+| 主模型、人类输入、默认 passthrough，thinking 开启或未指定 | 单次注入 | 历史不变；补丁只进本轮 user 尾部,实测 Vertex 默认不校验前缀绑定 |
 | 主模型、显式 disabled、人类输入 | 单次注入 | 不强行启用 adaptive，不自动加 beta；已有失配历史仍可能报错 |
 | 主模型、人类输入、drop_block | 单次注入 | 保留 enabled/adaptive 参数，合并 binding 和 beta |
 | 纯 tool_result 续轮 | 不召回、不恢复旧补丁 | drop_block 设置仍发送；历史所有块顺序不变 |
@@ -39,7 +39,7 @@
 
 `drop_block` 只让上游丢弃失配的块及受其影响的后续块，不是网关删除全部 thinking。
 它会牺牲部分推理连续性。用户改回 passthrough 或 disabled 后，先前已失配的历史不会自动恢复。
-如果上游不支持 binding beta，不能同时承诺“随请求撤除记忆”和“后续保留有效签名”；本版不维护注入补丁状态。
+如果上游强制校验前缀绑定(目前未发现默认开启的线路),该线路应改 drop_block 或显式 disabled;本版不维护注入补丁状态。
 
 ## 验证范围
 

--- a/src/gateway/handler.ts
+++ b/src/gateway/handler.ts
@@ -10,7 +10,7 @@ import type { Env } from "../types";
 import { newId } from "../utils/ids";
 import { nowIso } from "../utils/time";
 import { findIdentity, identityNamespace, identityReadNamespaces, isMainModel, loadConfig, type Identity, type Protocol } from "./config";
-import { appendMemory, classifyTurn, hasServerState, memoryThinkingCompatible, recentHumanTexts, validateBody, type Body } from "./protocol";
+import { appendMemory, classifyTurn, hasServerState, recentHumanTexts, validateBody, type Body } from "./protocol";
 import { RequestContractError } from "./request";
 import { dispatchExchange, persistHumanUtterance, observeResponse, prepareExchange } from "./record";
 import { callGatewayUpstream, prepareGatewayRequest, UpstreamRouteError } from "./upstream";
@@ -230,9 +230,7 @@ export async function handleGateway(request: Request, env: Env, ctx: ExecutionCo
       console.error("gateway human utterance persist failed", { identity: identity.slug, error });
     }
   }
-  const thinkingCompatible = memoryThinkingCompatible(prepared.body, protocol, prepared.headers);
-  if (main && turn.kind === "human" && !thinkingCompatible) memoryStatus = "skipped-thinking";
-  if (main && turn.kind === "human" && turn.text && thinkingCompatible) {
+  if (main && turn.kind === "human" && turn.text) {
     try {
       const prior = recentHumanTexts(body, protocol).slice(0, -1).slice(-3);
       patch = await recallPatch(env, identity, turn.text, ctx, prior, {

--- a/src/gateway/protocol.ts
+++ b/src/gateway/protocol.ts
@@ -92,12 +92,6 @@ export function sanitizeCacheControl(body: Body, protocol: Protocol): void {
   const last = lastCacheableBlock(body, true);
   if (object(last) && !last.cache_control) last.cache_control = cc;
 }
-/** A new signature binds today's injected memory, even if old signatures precede it. */
-export function memoryThinkingCompatible(body: Body, protocol: Protocol, headers: Headers): boolean {
-  if (protocol !== "messages" || body.thinking?.type === "disabled") return true;
-  return body.thinking?.block_binding?.prefix_mismatch_behavior === "drop_block" &&
-    (headers.get("anthropic-beta") || "").split(",").map(s => s.trim()).includes("thinking-binding-controls-2026-08-01");
-}
 // Encrypted reasoning stays allowed; only server-owned history breaks request-only memory.
 export function hasServerState(body: Body, protocol: Protocol): boolean {
   return protocol === "responses" && !!(body.previous_response_id || body.conversation ||

--- a/tests/gateway.test.ts
+++ b/tests/gateway.test.ts
@@ -283,13 +283,13 @@ test("missing CF token fails loudly instead of leaking another credential", asyn
   assert.match(JSON.parse(text).error.message, /CLOUDFLARE_API_TOKEN/);
   assert.equal(queue.length, 0); // Preflight fails before recording.
 });
-test("thinking passthrough preserves reasoning without creating ephemeral prefix bindings", async () => {
+test("thinking passthrough preserves reasoning and still injects memory", async () => {
   precious("partner-a", "Cloudflare fan");
   setConfig(config([{ ...identity(), anthropicThinking: "passthrough" }]));
   const body = { model: "partner", max_tokens: 2048, messages: [{ role: "user", content: "Hi Cloudflare" }], thinking: { type: "adaptive" } };
-  assert.equal((await run("/v1/messages", body)).response.headers.get("x-aelios-memory"), "skipped-thinking");
+  assert.equal((await run("/v1/messages", body)).response.headers.get("x-aelios-memory"), "injected");
   assert.deepEqual(calls[0].query.thinking, body.thinking);
-  assert.deepEqual(calls[0].query.messages, body.messages);
+  assert.ok(calls[0].query.messages[0].content.includes("Cloudflare fan"));
   assert.equal((await run("/v1/messages", { ...body, thinking: { type: "disabled" } })).response.headers.get("x-aelios-memory"), "injected");
 });
 test("automatic caching lowers to the last cacheable block without rewriting system", async () => {

--- a/tests/request-contract.test.ts
+++ b/tests/request-contract.test.ts
@@ -1,7 +1,7 @@
 import { strict as assert } from "node:assert";
 import { test } from "node:test";
 import { normalizeRequest, validateRequest, RequestContractError } from "../src/gateway/request";
-import { appendMemory, applyThinkingPolicy, memoryThinkingCompatible, sanitizeCacheControl } from "../src/gateway/protocol";
+import { appendMemory, applyThinkingPolicy, sanitizeCacheControl } from "../src/gateway/protocol";
 
 const base = () => ({ model: "claude-test", max_tokens: 2048, messages: [{ role: "user", content: "hello" }] });
 const assistant = { role: "assistant", content: [
@@ -113,11 +113,7 @@ test("the binding policy is present through tool continuations and later signed 
     assert.equal(body.thinking.block_binding.prefix_mismatch_behavior, "drop_block");
     assert.equal(headers.get("anthropic-beta")!.split(",").length, 2);
     assert.deepEqual(messages, before);
-    assert.equal(memoryThinkingCompatible(body, "messages", headers), true);
     assert.doesNotThrow(() => validateRequest(body, "messages", headers));
-  }
-  for (const thinking of [undefined, { type: "adaptive" }, { type: "enabled", budget_tokens: 1024 }]) {
-    assert.equal(memoryThinkingCompatible({ ...base(), thinking }, "messages", new Headers()), false);
   }
   const disabled: any = { ...base(), thinking: { type: "disabled" }, messages: [base().messages[0], assistant, result] };
   const before = structuredClone(disabled);


### PR DESCRIPTION
## 背景
0256417 在 thinking 直通时跳过注入(skipped-thinking),理由是「注入补丁会进入新生成 thinking 的签名前缀,下轮撤销补丁导致签名失配」。咲咲的要求是 thinking 和召回都要。

## 决定性实验(对生产 custom-navy/Vertex 线路)
1. 第一轮:user 消息尾部手动携带 `<memory-hint>` 补丁 + thinking adaptive → 200,拿到签名 thinking 块。
2. 第二轮:历史里撤掉补丁、保留签名块,继续对话 → **200**,签名验证通过。
3. 结论:Vertex 默认不校验 thinking 的前缀绑定,补丁撤出不会造成失配。GPT 的担心只在客户端显式携带 block_binding 时才成立。
4. 附带实测:drop_block 模式在 Vertex 直接 400 `unrecognizedProperty=block_binding`,该模式不可用于 Vertex 线路(已在文档标注)。

## 改动
- handler.ts/protocol.ts:删除 memoryThinkingCompatible 门,主模型人类输入轮无条件召回注入。
- 测试:passthrough 用例改为断言 injected;删除门函数的契约断言。
- 文档:memory-gateway.md / request-contract.md 的 thinking 矩阵按实测更新。

verify 全绿:gateway 61 / recall 19 / diary 4。