### PR TITLE
feat(gateway): 身份级 autoCache——客户端不带断点时网关补(rikkahub)

### DIFF
--- a/docs/memory-gateway.md
+++ b/docs/memory-gateway.md
@@ -155,6 +155,9 @@ Anthropic token counting。使用这些额外端点的客户端需要后续适�
 顶层 `cache_control` 是 Anthropic 已支持的自动缓存字段，但部分 Vertex/代理线路仍会拒绝。
 为兼容现有线路，网关把它转换成注入前最后一个可缓存块上的显式断点；已有断点保留，TTL 冲突或超过 4 个提前返回 400。
 没有顶层缓存设置就不主动添加断点。这个转换不等于保证所有上游支持同一套特性。
+身份级 `autoCache: true`(面板「高级」里)时,主模型请求若完全不带缓存断点,网关补两个 ephemeral 断点:
+system 前缀末尾和末轮尾部,让下一轮读到上一轮为止的全部前缀。补丁注入发生在断点之后,不进缓存前缀,
+不会每轮冲掉缓存。客户端自带任何断点(顶层或块级)时网关一律不加。
 响应头 `x-aelios-identity/memory/provider/model` 用于诊断；实际模型与 Provider 优先读取 `cf-aig-model/provider`。
 `x-aelios-normalized` 表示删除的非规范字段数量，Worker 日志列出字段路径，不记录被删除的值。
 

--- a/src/api/admin/ui.ts
+++ b/src/api/admin/ui.ts
@@ -1001,6 +1001,7 @@ document.documentElement.dataset.theme = localStorage.getItem('aelios.admin.colo
                   <option value="passthrough">原样透传(思考开着时跳过注入)</option>
                   <option value="drop_block">临时记忆 + 上游丢弃失配思考(需 beta)</option>
                 </select>
+                <label class="mt-2 flex items-center gap-1.5 text-xs text-zinc-400"><input type="checkbox" x-model="idn.autoCache" class="h-4 w-4 accent-[#f4a07c]"><span>自动缓存断点(客户端不带时由网关补,如 rikkahub)</span></label>
                 <label class="mt-2 block text-xs text-zinc-400">单次记忆字数上限</label>
                 <input x-model="idn.maxMemoryChars" type="number" min="256" max="24000" class="mt-1 h-10 w-full rounded-xl border border-zinc-800 bg-zinc-900 px-3 text-sm text-zinc-100 outline-none focus:border-coral" placeholder="留空默认 6000">
               </details>
@@ -1212,7 +1213,8 @@ function memoryAdmin() {
             readNamespacesText: idn.readNamespaces ? (idn.readNamespaces.length ? idn.readNamespaces.join(', ') : '[]') : '',
             keys: idn.keys && idn.keys.length ? idn.keys.slice() : ['CHATBOX_API_KEY'],
             anthropicThinking: idn.anthropicThinking || 'passthrough',
-            maxMemoryChars: idn.maxMemoryChars || ''
+            maxMemoryChars: idn.maxMemoryChars || '',
+            autoCache: idn.autoCache === true
           };
         });
         const envData = await this.request('/api/gateway/env');
@@ -1223,7 +1225,7 @@ function memoryAdmin() {
       this.gwBusy = false;
     },
     gwAdd() {
-      this.gwIdentities.push({ slug: '', modelsText: '', namespace: '', readNamespacesText: '', keys: ['CHATBOX_API_KEY'], anthropicThinking: 'passthrough', maxMemoryChars: '' });
+      this.gwIdentities.push({ slug: '', modelsText: '', namespace: '', readNamespacesText: '', keys: ['CHATBOX_API_KEY'], anthropicThinking: 'passthrough', maxMemoryChars: '', autoCache: false });
     },
     async gwSave() {
       if (this.gwBusy) return;
@@ -1239,6 +1241,7 @@ function memoryAdmin() {
           const reads = (idn.readNamespacesText || '').trim();
           if (reads) out.readNamespaces = reads === '[]' ? [] : reads.split(/[,，\n]/).map(function(s) { return s.trim(); }).filter(Boolean);
           if (idn.anthropicThinking && idn.anthropicThinking !== 'passthrough') out.anthropicThinking = idn.anthropicThinking;
+          if (idn.autoCache) out.autoCache = true;
           const budget = parseInt(idn.maxMemoryChars, 10);
           if (budget) out.maxMemoryChars = budget;
           return out;

--- a/src/gateway/config.ts
+++ b/src/gateway/config.ts
@@ -23,6 +23,8 @@ export interface Identity {
   models: string[];
   anthropicThinking?: "passthrough" | "drop_block";
   maxMemoryChars?: number;
+  /** 客户端不带 cache_control 时,由网关在 system 末尾和末轮补上 ephemeral 断点。 */
+  autoCache?: boolean;
 }
 export interface GatewayConfig {
   version: 3;
@@ -74,6 +76,7 @@ export function validateConfig(value: unknown): GatewayConfig {
       identity.models.every((m: unknown) => text(m) && (m as string).length <= 200),
       `${where}: models must be an array of at most 64 model names`);
     check(identity.anthropicThinking === undefined || ["passthrough", "drop_block"].includes(identity.anthropicThinking), `${where}: invalid anthropicThinking`);
+    check(identity.autoCache === undefined || typeof identity.autoCache === "boolean", `${where}: autoCache must be a boolean`);
     check(identity.maxMemoryChars === undefined || Number.isInteger(identity.maxMemoryChars) && identity.maxMemoryChars >= 256 && identity.maxMemoryChars <= 24000, `${where}: maxMemoryChars must be 256–24000`);
   }
   return value as unknown as GatewayConfig;

--- a/src/gateway/handler.ts
+++ b/src/gateway/handler.ts
@@ -10,7 +10,7 @@ import type { Env } from "../types";
 import { newId } from "../utils/ids";
 import { nowIso } from "../utils/time";
 import { findIdentity, identityNamespace, identityReadNamespaces, isMainModel, loadConfig, type Identity, type Protocol } from "./config";
-import { appendMemory, classifyTurn, hasServerState, recentHumanTexts, validateBody, type Body } from "./protocol";
+import { appendMemory, autoCacheBreakpoints, classifyTurn, hasServerState, recentHumanTexts, validateBody, type Body } from "./protocol";
 import { RequestContractError } from "./request";
 import { dispatchExchange, persistHumanUtterance, observeResponse, prepareExchange } from "./record";
 import { callGatewayUpstream, prepareGatewayRequest, UpstreamRouteError } from "./upstream";
@@ -216,6 +216,8 @@ export async function handleGateway(request: Request, env: Env, ctx: ExecutionCo
       error instanceof RequestContractError || error instanceof UpstreamRouteError ? 400 : 502);
   }
   if (prepared.removed.length) console.log("gateway request normalized", { protocol, removed: prepared.removed });
+  // Clients without cache_control (rikkahub) get gateway-side ephemeral breakpoints.
+  if (main && identity.autoCache && protocol === "messages") autoCacheBreakpoints(prepared.body);
   let patch = "";
   let memoryStatus = !main ? "off" : turn.kind !== "human" ? "skipped" : "empty";
   let rememberStatus = "none";

--- a/src/gateway/protocol.ts
+++ b/src/gateway/protocol.ts
@@ -92,6 +92,33 @@ export function sanitizeCacheControl(body: Body, protocol: Protocol): void {
   const last = lastCacheableBlock(body, true);
   if (object(last) && !last.cache_control) last.cache_control = cc;
 }
+// Identity-level automatic caching for clients that send no breakpoints at all
+// (rikkahub): mark the end of the system prefix plus the final turn's tail, so the
+// next turn cache-reads everything up to the previous tail. Any client-supplied
+// marker (top-level or block) wins and nothing is added.
+export function autoCacheBreakpoints(body: Body): boolean {
+  if (body.cache_control !== undefined) return false;
+  const marked = (v: unknown): boolean => Array.isArray(v) && v.some(b => object(b) && b.cache_control !== undefined);
+  if (marked(body.system) || marked(body.tools)) return false;
+  for (const m of body.messages ?? []) if (marked(m?.content)) return false;
+  const cc = { type: "ephemeral" };
+  let added = false;
+  if (typeof body.system === "string" && body.system) {
+    body.system = [{ type: "text", text: body.system, cache_control: cc }];
+    added = true;
+  } else if (Array.isArray(body.system)) {
+    for (let i = body.system.length - 1; i >= 0; i--) {
+      const block = body.system[i];
+      if (object(block) && CACHEABLE.has(block.type)) { block.cache_control = cc; added = true; break; }
+    }
+  }
+  const tail = lastCacheableBlock(body, true);
+  if (tail && tail.cache_control === undefined && !(Array.isArray(body.system) && body.system.at(-1) === tail)) {
+    tail.cache_control = cc;
+    added = true;
+  }
+  return added;
+}
 // Encrypted reasoning stays allowed; only server-owned history breaks request-only memory.
 export function hasServerState(body: Body, protocol: Protocol): boolean {
   return protocol === "responses" && !!(body.previous_response_id || body.conversation ||

--- a/tests/gateway.test.ts
+++ b/tests/gateway.test.ts
@@ -309,6 +309,22 @@ test("automatic caching lowers to the last cacheable block without rewriting sys
   await run("/v1/messages", noSystem);
   assert.deepEqual(calls[2].query.messages[0].content[0].cache_control, cc);
 });
+test("autoCache identity gets gateway-side ephemeral breakpoints; client markers win", async () => {
+  setConfig(config([{ ...identity(), autoCache: true }]));
+  const body = { model: "partner", max_tokens: 16, system: [{ type: "text", text: "persona" }],
+    messages: [{ role: "user", content: "Hi" }] };
+  const { response } = await run("/v1/messages", body);
+  assert.equal(response.status, 200);
+  assert.deepEqual(calls[0].query.system[0].cache_control, { type: "ephemeral" });
+  assert.deepEqual(calls[0].query.messages[0].content.at(-1).cache_control, { type: "ephemeral" });
+  const cc = { type: "ephemeral", ttl: "1h" };
+  await run("/v1/messages", { ...body, messages: [{ role: "user", content: [{ type: "text", text: "Hi", cache_control: cc }] }] });
+  assert.equal(calls[1].query.system[0].cache_control, undefined);
+  assert.deepEqual(calls[1].query.messages[0].content[0].cache_control, cc);
+  await run("/v1/messages", { ...body, model: "other" });
+  assert.equal(calls[2].query.system[0].cache_control, undefined);
+  assert.equal(calls[2].query.messages[0].content, "Hi");
+});
 test("Queue failure falls back to D1; successful duplicate cannot overwrite complete record", async () => {
   await run("/v1/chat/completions", { model: "partner", messages: [{ role: "user", content: "Hi" }] });
   env.MEMORY_QUEUE.send = async () => { throw Error("queue unavailable"); };


### PR DESCRIPTION
## 背景
rikkahub 等客户端完全不带 cache_control(生产日志实测:块级顶层皆零)。身份开 `autoCache: true` 后,网关给主模型请求补两个 ephemeral 断点:system 前缀末尾 + 末轮尾部,下一轮即可 cache-read 到上一轮为止的全部前缀。

- 客户端自带任何断点(顶层或块级)一律不加;非主模型不动
- 记忆补丁注入在断点之后,不进缓存前缀,不会每轮冲掉缓存
- 面板「高级」新增开关;配置校验 autoCache 必须为布尔
- 新增测试三情形:补断点 / 客户端标记优先 / 非主模型不动

verify 全绿:gateway 62 / recall 19 / diary 4。

用法:merge 部署后,面板旦九 → 高级 → 勾「自动缓存断点」→ 保存。rikkahub 连聊两轮,第二轮日志里 cache_read 应起飞。