### PR TITLE
fix(gateway): 学习剥除 Vertex 拒收的工具级 cache_control;撤销 autoCache

### DIFF
--- a/docs/memory-gateway.md
+++ b/docs/memory-gateway.md
@@ -157,9 +157,6 @@ Anthropic token counting。使用这些额外端点的客户端需要后续适�
 顶层 `cache_control` 是 Anthropic 已支持的自动缓存字段，但部分 Vertex/代理线路仍会拒绝。
 为兼容现有线路，网关把它转换成注入前最后一个可缓存块上的显式断点；已有断点保留，TTL 冲突或超过 4 个提前返回 400。
 没有顶层缓存设置就不主动添加断点。这个转换不等于保证所有上游支持同一套特性。
-身份级 `autoCache: true`(面板「高级」里)时,主模型请求若完全不带缓存断点,网关补两个 ephemeral 断点:
-system 前缀末尾和末轮尾部,让下一轮读到上一轮为止的全部前缀。补丁注入发生在断点之后,不进缓存前缀,
-不会每轮冲掉缓存。客户端自带任何断点(顶层或块级)时网关一律不加。
 响应头 `x-aelios-identity/memory/provider/model` 用于诊断；实际模型与 Provider 优先读取 `cf-aig-model/provider`。
 `x-aelios-normalized` 表示删除的非规范字段数量，Worker 日志列出字段路径，不记录被删除的值。
 

--- a/docs/memory-gateway.md
+++ b/docs/memory-gateway.md
@@ -157,6 +157,11 @@ Anthropic token counting。使用这些额外端点的客户端需要后续适�
 顶层 `cache_control` 是 Anthropic 已支持的自动缓存字段，但部分 Vertex/代理线路仍会拒绝。
 为兼容现有线路，网关把它转换成注入前最后一个可缓存块上的显式断点；已有断点保留，TTL 冲突或超过 4 个提前返回 400。
 没有顶层缓存设置就不主动添加断点。这个转换不等于保证所有上游支持同一套特性。
+工具定义上的断点同理:实测 Vertex 线路拒绝工具级 cache_control(400 unrecognizedProperty),system/user 位置正常。
+网关按「学习」处理:某条线路 400 报这个签名,剥掉工具断点重试一次,并在本 isolate 记住,之后请求预先剥除;
+支持工具断点的线路永远学不到这条,不受影响。
+为兼容现有线路，网关把它转换成注入前最后一个可缓存块上的显式断点；已有断点保留，TTL 冲突或超过 4 个提前返回 400。
+没有顶层缓存设置就不主动添加断点。这个转换不等于保证所有上游支持同一套特性。
 响应头 `x-aelios-identity/memory/provider/model` 用于诊断；实际模型与 Provider 优先读取 `cf-aig-model/provider`。
 `x-aelios-normalized` 表示删除的非规范字段数量，Worker 日志列出字段路径，不记录被删除的值。
 

--- a/src/api/admin/ui.ts
+++ b/src/api/admin/ui.ts
@@ -1001,7 +1001,6 @@ document.documentElement.dataset.theme = localStorage.getItem('aelios.admin.colo
                   <option value="passthrough">原样透传(思考开着时跳过注入)</option>
                   <option value="drop_block">临时记忆 + 上游丢弃失配思考(需 beta)</option>
                 </select>
-                <label class="mt-2 flex items-center gap-1.5 text-xs text-zinc-400"><input type="checkbox" x-model="idn.autoCache" class="h-4 w-4 accent-[#f4a07c]"><span>自动缓存断点(客户端不带时由网关补,如 rikkahub)</span></label>
                 <label class="mt-2 block text-xs text-zinc-400">单次记忆字数上限</label>
                 <input x-model="idn.maxMemoryChars" type="number" min="256" max="24000" class="mt-1 h-10 w-full rounded-xl border border-zinc-800 bg-zinc-900 px-3 text-sm text-zinc-100 outline-none focus:border-coral" placeholder="留空默认 6000">
               </details>
@@ -1213,8 +1212,7 @@ function memoryAdmin() {
             readNamespacesText: idn.readNamespaces ? (idn.readNamespaces.length ? idn.readNamespaces.join(', ') : '[]') : '',
             keys: idn.keys && idn.keys.length ? idn.keys.slice() : ['CHATBOX_API_KEY'],
             anthropicThinking: idn.anthropicThinking || 'passthrough',
-            maxMemoryChars: idn.maxMemoryChars || '',
-            autoCache: idn.autoCache === true
+            maxMemoryChars: idn.maxMemoryChars || ''
           };
         });
         const envData = await this.request('/api/gateway/env');
@@ -1225,7 +1223,7 @@ function memoryAdmin() {
       this.gwBusy = false;
     },
     gwAdd() {
-      this.gwIdentities.push({ slug: '', modelsText: '', namespace: '', readNamespacesText: '', keys: ['CHATBOX_API_KEY'], anthropicThinking: 'passthrough', maxMemoryChars: '', autoCache: false });
+      this.gwIdentities.push({ slug: '', modelsText: '', namespace: '', readNamespacesText: '', keys: ['CHATBOX_API_KEY'], anthropicThinking: 'passthrough', maxMemoryChars: '' });
     },
     async gwSave() {
       if (this.gwBusy) return;
@@ -1241,7 +1239,6 @@ function memoryAdmin() {
           const reads = (idn.readNamespacesText || '').trim();
           if (reads) out.readNamespaces = reads === '[]' ? [] : reads.split(/[,，\n]/).map(function(s) { return s.trim(); }).filter(Boolean);
           if (idn.anthropicThinking && idn.anthropicThinking !== 'passthrough') out.anthropicThinking = idn.anthropicThinking;
-          if (idn.autoCache) out.autoCache = true;
           const budget = parseInt(idn.maxMemoryChars, 10);
           if (budget) out.maxMemoryChars = budget;
           return out;

--- a/src/gateway/config.ts
+++ b/src/gateway/config.ts
@@ -23,8 +23,6 @@ export interface Identity {
   models: string[];
   anthropicThinking?: "passthrough" | "drop_block";
   maxMemoryChars?: number;
-  /** 客户端不带 cache_control 时,由网关在 system 末尾和末轮补上 ephemeral 断点。 */
-  autoCache?: boolean;
 }
 export interface GatewayConfig {
   version: 3;
@@ -76,7 +74,6 @@ export function validateConfig(value: unknown): GatewayConfig {
       identity.models.every((m: unknown) => text(m) && (m as string).length <= 200),
       `${where}: models must be an array of at most 64 model names`);
     check(identity.anthropicThinking === undefined || ["passthrough", "drop_block"].includes(identity.anthropicThinking), `${where}: invalid anthropicThinking`);
-    check(identity.autoCache === undefined || typeof identity.autoCache === "boolean", `${where}: autoCache must be a boolean`);
     check(identity.maxMemoryChars === undefined || Number.isInteger(identity.maxMemoryChars) && identity.maxMemoryChars >= 256 && identity.maxMemoryChars <= 24000, `${where}: maxMemoryChars must be 256–24000`);
   }
   return value as unknown as GatewayConfig;

--- a/src/gateway/handler.ts
+++ b/src/gateway/handler.ts
@@ -10,7 +10,7 @@ import type { Env } from "../types";
 import { newId } from "../utils/ids";
 import { nowIso } from "../utils/time";
 import { findIdentity, identityNamespace, identityReadNamespaces, isMainModel, loadConfig, type Identity, type Protocol } from "./config";
-import { appendMemory, autoCacheBreakpoints, classifyTurn, hasServerState, inputItems, recentHumanTexts, validateBody, visibleText, type Body } from "./protocol";
+import { appendMemory, classifyTurn, hasServerState, inputItems, recentHumanTexts, validateBody, visibleText, type Body } from "./protocol";
 import { RequestContractError } from "./request";
 import { dispatchExchange, persistHumanUtterance, observeResponse, prepareExchange } from "./record";
 import { callGatewayUpstream, prepareGatewayRequest, UpstreamRouteError } from "./upstream";
@@ -217,8 +217,6 @@ export async function handleGateway(request: Request, env: Env, ctx: ExecutionCo
       error instanceof RequestContractError || error instanceof UpstreamRouteError ? 400 : 502);
   }
   if (prepared.removed.length) console.log("gateway request normalized", { protocol, removed: prepared.removed });
-  // Clients without cache_control (rikkahub) get gateway-side ephemeral breakpoints.
-  if (main && identity.autoCache && protocol === "messages") autoCacheBreakpoints(prepared.body);
   let patch = "";
   let memoryStatus = !main ? "off" : turn.kind !== "human" ? "skipped" : "empty";
   let rememberStatus = "none";

--- a/src/gateway/handler.ts
+++ b/src/gateway/handler.ts
@@ -13,7 +13,7 @@ import { findIdentity, identityNamespace, identityReadNamespaces, isMainModel, l
 import { appendMemory, classifyTurn, hasServerState, inputItems, recentHumanTexts, validateBody, visibleText, type Body } from "./protocol";
 import { RequestContractError } from "./request";
 import { dispatchExchange, persistHumanUtterance, observeResponse, prepareExchange } from "./record";
-import { callGatewayUpstream, prepareGatewayRequest, UpstreamRouteError } from "./upstream";
+import { callGatewayUpstream, prepareGatewayRequest, UpstreamRouteError, type PreparedRequest } from "./upstream";
 
 export function gatewayError(protocol: Protocol, message: string, status: number): Response {
   const type = status === 401 ? "authentication_error" : status >= 500 ? "api_error" : "invalid_request_error";
@@ -210,7 +210,7 @@ export async function handleGateway(request: Request, env: Env, ctx: ExecutionCo
     return gatewayError(protocol, "Request-only memory requires stateless Responses input: send full history without previous_response_id, conversation or item_reference; or use a model outside the main list.", 400);
   }
   const turn = classifyTurn(body, protocol, request.headers.get("x-aelios-purpose") === "auxiliary");
-  let prepared: ReturnType<typeof prepareGatewayRequest>;
+  let prepared: PreparedRequest;
   try { prepared = prepareGatewayRequest(env, config, identity, protocol, request, body); }
   catch (error) {
     return gatewayError(protocol, error instanceof Error ? error.message : "Invalid upstream request",

--- a/src/gateway/protocol.ts
+++ b/src/gateway/protocol.ts
@@ -92,33 +92,6 @@ export function sanitizeCacheControl(body: Body, protocol: Protocol): void {
   const last = lastCacheableBlock(body, true);
   if (object(last) && !last.cache_control) last.cache_control = cc;
 }
-// Identity-level automatic caching for clients that send no breakpoints at all
-// (rikkahub): mark the end of the system prefix plus the final turn's tail, so the
-// next turn cache-reads everything up to the previous tail. Any client-supplied
-// marker (top-level or block) wins and nothing is added.
-export function autoCacheBreakpoints(body: Body): boolean {
-  if (body.cache_control !== undefined) return false;
-  const marked = (v: unknown): boolean => Array.isArray(v) && v.some(b => object(b) && b.cache_control !== undefined);
-  if (marked(body.system) || marked(body.tools)) return false;
-  for (const m of body.messages ?? []) if (marked(m?.content)) return false;
-  const cc = { type: "ephemeral" };
-  let added = false;
-  if (typeof body.system === "string" && body.system) {
-    body.system = [{ type: "text", text: body.system, cache_control: cc }];
-    added = true;
-  } else if (Array.isArray(body.system)) {
-    for (let i = body.system.length - 1; i >= 0; i--) {
-      const block = body.system[i];
-      if (object(block) && CACHEABLE.has(block.type)) { block.cache_control = cc; added = true; break; }
-    }
-  }
-  const tail = lastCacheableBlock(body, true);
-  if (tail && tail.cache_control === undefined && !(Array.isArray(body.system) && body.system.at(-1) === tail)) {
-    tail.cache_control = cc;
-    added = true;
-  }
-  return added;
-}
 // Encrypted reasoning stays allowed; only server-owned history breaks request-only memory.
 export function hasServerState(body: Body, protocol: Protocol): boolean {
   return protocol === "responses" && !!(body.previous_response_id || body.conversation ||

--- a/src/gateway/protocol.ts
+++ b/src/gateway/protocol.ts
@@ -92,6 +92,16 @@ export function sanitizeCacheControl(body: Body, protocol: Protocol): void {
   const last = lastCacheableBlock(body, true);
   if (object(last) && !last.cache_control) last.cache_control = cc;
 }
+// Vertex-backed lines reject cache_control on tool definitions
+// (INVALID_ARGUMENT unrecognizedProperty=cache_control); system/user markers are fine.
+// The gateway learns this per upstream and strips only tool breakpoints there.
+export function stripToolCacheControl(body: Body): boolean {
+  let stripped = false;
+  for (const tool of body.tools ?? []) {
+    if (object(tool) && tool.cache_control !== undefined) { delete tool.cache_control; stripped = true; }
+  }
+  return stripped;
+}
 // Encrypted reasoning stays allowed; only server-owned history breaks request-only memory.
 export function hasServerState(body: Body, protocol: Protocol): boolean {
   return protocol === "responses" && !!(body.previous_response_id || body.conversation ||

--- a/src/gateway/upstream.ts
+++ b/src/gateway/upstream.ts
@@ -1,6 +1,6 @@
 import type { Env } from "../types";
 import { isMainModel, PATHS, type GatewayConfig, type Identity, type Protocol } from "./config";
-import { applyThinkingPolicy, sanitizeCacheControl, type Body } from "./protocol";
+import { applyThinkingPolicy, sanitizeCacheControl, stripToolCacheControl, type Body } from "./protocol";
 import { normalizeRequest, validateRequest } from "./request";
 
 const ACCOUNT_RE = /^[a-f0-9]{32}$/i;
@@ -113,8 +113,9 @@ export function routeFor(resolved: ResolvedUpstream, protocol: Protocol, model: 
 
 // One call, one upstream. Model names pass through as written (minus the provider
 // prefix on native endpoints); retries and fallback are AI Gateway's own job.
+export interface PreparedRequest { route: UpstreamRoute; headers: Headers; body: Body; removed: string[] }
 export function prepareGatewayRequest(env: Env, config: GatewayConfig, identity: Identity,
-  protocol: Protocol, original: Request, body: Body) {
+  protocol: Protocol, original: Request, body: Body): PreparedRequest {
   const token = env.CLOUDFLARE_API_TOKEN;
   if (!token) throw new Error("Missing Worker secret CLOUDFLARE_API_TOKEN");
   const route = routeFor(resolveUpstream(env, config), protocol, body.model);
@@ -138,12 +139,25 @@ export function prepareGatewayRequest(env: Env, config: GatewayConfig, identity:
   validateRequest(out, protocol, headers);
   return { route, headers, body: out, removed: normalized.removed };
 }
+// Isolate-scope learned capability: Vertex-backed providers answer 400
+// "unrecognizedProperty=cache_control" to tool breakpoints. One learning 400 per
+// isolate per route; afterwards tool breakpoints are stripped before sending.
+export const toolCacheRejections = new Set<string>();
+
 export async function callGatewayUpstream(protocol: Protocol, original: Request,
-  prepared: ReturnType<typeof prepareGatewayRequest>, body: Body): Promise<Response> {
+  prepared: PreparedRequest, body: Body): Promise<Response> {
   const { route, headers } = prepared;
   // Check the actual wire payload, including the gateway's own modifications.
   validateRequest(body, protocol, headers);
-  return fetch(route.url, {
+  if (toolCacheRejections.has(route.url)) stripToolCacheControl(body);
+  const send = () => fetch(route.url, {
     method: "POST", headers, body: JSON.stringify(body), signal: original.signal, redirect: "manual"
   });
+  const first = await send();
+  if (first.status !== 400) return first;
+  const detail = await first.clone().text().catch(() => "");
+  if (!/unrecognizedProperty=cache_control/.test(detail) || !stripToolCacheControl(body)) return first;
+  toolCacheRejections.add(route.url);
+  console.log("gateway learned upstream rejects tool cache_control", { url: route.url });
+  return send();
 }

--- a/tests/gateway.test.ts
+++ b/tests/gateway.test.ts
@@ -309,22 +309,6 @@ test("automatic caching lowers to the last cacheable block without rewriting sys
   await run("/v1/messages", noSystem);
   assert.deepEqual(calls[2].query.messages[0].content[0].cache_control, cc);
 });
-test("autoCache identity gets gateway-side ephemeral breakpoints; client markers win", async () => {
-  setConfig(config([{ ...identity(), autoCache: true }]));
-  const body = { model: "partner", max_tokens: 16, system: [{ type: "text", text: "persona" }],
-    messages: [{ role: "user", content: "Hi" }] };
-  const { response } = await run("/v1/messages", body);
-  assert.equal(response.status, 200);
-  assert.deepEqual(calls[0].query.system[0].cache_control, { type: "ephemeral" });
-  assert.deepEqual(calls[0].query.messages[0].content.at(-1).cache_control, { type: "ephemeral" });
-  const cc = { type: "ephemeral", ttl: "1h" };
-  await run("/v1/messages", { ...body, messages: [{ role: "user", content: [{ type: "text", text: "Hi", cache_control: cc }] }] });
-  assert.equal(calls[1].query.system[0].cache_control, undefined);
-  assert.deepEqual(calls[1].query.messages[0].content[0].cache_control, cc);
-  await run("/v1/messages", { ...body, model: "other" });
-  assert.equal(calls[2].query.system[0].cache_control, undefined);
-  assert.equal(calls[2].query.messages[0].content, "Hi");
-});
 test("Queue failure falls back to D1; successful duplicate cannot overwrite complete record", async () => {
   await run("/v1/chat/completions", { model: "partner", messages: [{ role: "user", content: "Hi" }] });
   env.MEMORY_QUEUE.send = async () => { throw Error("queue unavailable"); };

--- a/tests/gateway.test.ts
+++ b/tests/gateway.test.ts
@@ -6,7 +6,7 @@ import { timingSafeEqual } from "node:crypto";
 import worker from "../src/index";
 import { identityNamespace, identityReadNamespaces, invalidateSettingsCache, validateConfig } from "../src/gateway/config";
 import { appendMemory, classifyTurn, canonical } from "../src/gateway/protocol";
-import { catalogUrl, resolveUpstream, routeFor } from "../src/gateway/upstream";
+import { catalogUrl, resolveUpstream, routeFor, toolCacheRejections } from "../src/gateway/upstream";
 import { OutputCollector, observeResponse, persistExchange, prepareExchange, dispatchExchange } from "../src/gateway/record";
 
 // Test actual production modules and SQL, replacing only the external HTTP call.
@@ -308,6 +308,35 @@ test("automatic caching lowers to the last cacheable block without rewriting sys
   const noSystem = { model: "partner", max_tokens: 16, cache_control: cc, messages: [{ role: "user", content: [{ type: "text", text: "Hi" }] }] };
   await run("/v1/messages", noSystem);
   assert.deepEqual(calls[2].query.messages[0].content[0].cache_control, cc);
+});
+test("upstream rejecting tool cache_control is learned: retry once stripped, then pre-strip", async () => {
+  toolCacheRejections.clear();
+  const vertexError = JSON.stringify({ errorCode: "INVALID_ARGUMENT",
+    parameters: { unsafeParams: "{unrecognizedProperty=cache_control}" }, message: "Request contained an unrecognized field" });
+  const baseFetch = globalThis.fetch;
+  const seen: any[] = [];
+  let fail = true;
+  globalThis.fetch = async (url: any, init: any) => {
+    seen.push(JSON.parse(init?.body as string));
+    if (fail) { fail = false; return new Response(vertexError, { status: 400 }); }
+    return baseFetch(url, init);
+  };
+  try {
+    const body = { model: "partner", max_tokens: 16,
+      tools: [{ name: "t", input_schema: { type: "object" }, cache_control: { type: "ephemeral" } }],
+      messages: [{ role: "user", content: "Hi" }] };
+    const { response } = await run("/v1/messages", body);
+    assert.equal(response.status, 200);
+    assert.equal(seen.length, 2);
+    assert.deepEqual(seen[0].tools[0].cache_control, { type: "ephemeral" });
+    assert.equal(seen[1].tools[0].cache_control, undefined);
+    await run("/v1/messages", body);
+    assert.equal(seen.length, 3);
+    assert.equal(seen[2].tools[0].cache_control, undefined);
+  } finally {
+    globalThis.fetch = baseFetch;
+    toolCacheRejections.clear();
+  }
 });
 test("Queue failure falls back to D1; successful duplicate cannot overwrite complete record", async () => {
   await run("/v1/chat/completions", { model: "partner", messages: [{ role: "user", content: "Hi" }] });


### PR DESCRIPTION
## 实测定位(生产 custom-navy/Vertex,逐位置消除实验)
| 断点位置 | 结果 |
|---|---|
| system 文本块 | 200 |
| user 文本块 | 200 |
| **工具定义** | **400 unrecognizedProperty=cache_control** |
| 不带断点 | 200 |

rikkahub(及 Claude Code 风格客户端)恰好都打工具断点,所以一开缓存就 400。咲咴的 cache_control 本身打得完全合法,是 Vertex 不收工具位。

## 改动
1. **学习型剥除**(protocol.ts stripToolCacheControl + upstream.ts):上游 400 报 `unrecognizedProperty=cache_control` 签名时,剥掉工具断点重试一次;本 isolate 记住该线路,之后请求预先剥除。nous 等支持工具断点的线路永远学不到,不受影响。无需配置。
2. **撤销 autoCache**(revert 9ff7074):按咲咴明确要求,不给不带 cache_control 的请求主动补断点。

## 验证
verify 全绿:gateway 62 / recall 20 / diary 4。新增测试:首个请求带工具断点 400→剥除重试 200;后续请求预先剥除,不再付 400。