### PR TITLE
feat(dream): write memories with configured speaker names

### DIFF
--- a/src/api/admin/ui.ts
+++ b/src/api/admin/ui.ts
@@ -1030,13 +1030,18 @@ document.documentElement.dataset.theme = localStorage.getItem('aelios.admin.colo
             <label class="text-xs text-zinc-400">助手</label>
             <button type="button" @click="gwAdd()" class="tap rounded-2xl border border-zinc-800 px-3 py-1.5 text-xs text-zinc-400 transition duration-150 ease-in-out hover:border-coral hover:text-zinc-100">+ 添加助手</button>
           </div>
-          <p class="mt-1 text-[11px] text-zinc-500">名字即地址路径段;主模型支持 * 通配,只有主模型有记忆、进 Dream。</p>
+          <p class="mt-1 text-[11px] text-zinc-500">名字即地址路径段;主模型支持 * 通配,只有主模型有记忆、进 Dream。用户名和助手名给 Dream 写记忆用,只许写名字,不许写用户/助手。</p>
           <template x-for="(idn, i) in gwIdentities" :key="i">
             <div class="mt-2 space-y-2 rounded-2xl border border-zinc-800 bg-[#0a0a0b] p-3">
               <div class="flex items-center gap-2">
                 <input x-model="idn.slug" class="h-10 min-w-0 flex-1 rounded-xl border border-zinc-800 bg-zinc-900 px-3 text-sm text-zinc-100 outline-none focus:border-coral" placeholder="名字,如 coder">
                 <button type="button" @click="gwIdentities.splice(i, 1)" class="tap shrink-0 rounded-xl border border-zinc-800 px-3 py-2 text-xs text-zinc-500 transition hover:border-coral hover:text-zinc-100">移除</button>
               </div>
+              <div class="grid grid-cols-2 gap-2">
+                <input x-model="idn.userName" class="h-10 w-full rounded-xl border border-zinc-800 bg-zinc-900 px-3 text-sm text-zinc-100 outline-none focus:border-coral" placeholder="用户叫什么,如 咲咲">
+                <input x-model="idn.assistantName" class="h-10 w-full rounded-xl border border-zinc-800 bg-zinc-900 px-3 text-sm text-zinc-100 outline-none focus:border-coral" placeholder="助手叫什么,如 旦九">
+              </div>
+              <p class="text-[11px] text-zinc-500">Dream 写记忆只用这两个名字。助手名留空则用路径名。</p>
               <input x-model="idn.modelsText" class="h-10 w-full rounded-xl border border-zinc-800 bg-zinc-900 px-3 text-sm text-zinc-100 outline-none focus:border-coral" placeholder="主模型,逗号分隔,如 anthropic/claude-opus-5, *fable*">
               <input x-model="idn.namespace" class="h-10 w-full rounded-xl border border-zinc-800 bg-zinc-900 px-3 text-sm text-zinc-100 outline-none focus:border-coral" placeholder="写入空间,留空与名字同名">
               <input x-model="idn.readNamespacesText" class="h-10 w-full rounded-xl border border-zinc-800 bg-zinc-900 px-3 text-sm text-zinc-100 outline-none focus:border-coral" placeholder="召回空间,逗号分隔;留空只读写入空间;[] 不召回">
@@ -1388,6 +1393,8 @@ function memoryAdmin() {
         this.gwIdentities = (config.identities || []).map(function(idn) {
           return {
             slug: idn.slug || '',
+            userName: idn.userName || '',
+            assistantName: idn.assistantName || '',
             modelsText: (idn.models || []).join(', '),
             namespace: idn.namespace || '',
             readNamespacesText: idn.readNamespaces ? (idn.readNamespaces.length ? idn.readNamespaces.join(', ') : '[]') : '',
@@ -1404,7 +1411,7 @@ function memoryAdmin() {
       this.gwBusy = false;
     },
     gwAdd() {
-      this.gwIdentities.push({ slug: '', modelsText: '', namespace: '', readNamespacesText: '', keys: ['CHATBOX_API_KEY'], anthropicThinking: 'passthrough', maxMemoryChars: '' });
+      this.gwIdentities.push({ slug: '', userName: '', assistantName: '', modelsText: '', namespace: '', readNamespacesText: '', keys: ['CHATBOX_API_KEY'], anthropicThinking: 'passthrough', maxMemoryChars: '' });
     },
     async gwSave() {
       if (this.gwBusy) return;
@@ -1416,6 +1423,8 @@ function memoryAdmin() {
             keys: idn.keys,
             models: (idn.modelsText || '').split(/[,，\n]/).map(function(s) { return s.trim(); }).filter(Boolean)
           };
+          if ((idn.userName || '').trim()) out.userName = idn.userName.trim();
+          if ((idn.assistantName || '').trim()) out.assistantName = idn.assistantName.trim();
           if ((idn.namespace || '').trim()) out.namespace = idn.namespace.trim();
           const reads = (idn.readNamespacesText || '').trim();
           if (reads) out.readNamespaces = reads === '[]' ? [] : reads.split(/[,，\n]/).map(function(s) { return s.trim(); }).filter(Boolean);

--- a/src/api/admin/ui.ts
+++ b/src/api/admin/ui.ts
@@ -316,6 +316,19 @@ document.documentElement.dataset.theme = localStorage.getItem('aelios.admin.colo
         </div>
         <p class="mt-2 text-xs leading-6 text-zinc-400" x-text="spaceDescription()"></p>
         <p class="text-xs leading-6 text-zinc-500">这里切换查看的记忆；客户端使用哪位助手由接入地址和钥匙决定。</p>
+        <div x-show="selectedIdentity" class="mt-3 rounded-xl border border-zinc-800 bg-[#0a0a0b] p-3">
+          <p class="text-xs text-zinc-400">说话人名字</p>
+          <p class="mt-1 text-[11px] leading-5 text-zinc-500">Dream、日记、周月卷、审核写记忆时只用这两个名字，不许写用户/助手。</p>
+          <div class="mt-2 grid gap-2 md:grid-cols-[1fr_1fr_auto] md:items-end">
+            <label class="text-xs text-zinc-400">用户叫什么
+              <input x-model="speakerUserName" class="mt-1 h-11 w-full rounded-xl border border-zinc-800 bg-zinc-900 px-3 text-sm text-zinc-100 outline-none focus:border-coral" placeholder="如 咲咲">
+            </label>
+            <label class="text-xs text-zinc-400">助手叫什么
+              <input x-model="speakerAssistantName" class="mt-1 h-11 w-full rounded-xl border border-zinc-800 bg-zinc-900 px-3 text-sm text-zinc-100 outline-none focus:border-coral" placeholder="如 旦九；留空用路径名">
+            </label>
+            <button type="button" @click="saveSpeakers()" :disabled="speakerBusy" class="tap h-11 rounded-2xl bg-coral px-4 text-sm font-semibold text-zinc-950 transition duration-150 ease-in-out active:bg-coral/80 disabled:opacity-60">保存名字</button>
+          </div>
+        </div>
         <p x-show="identityLoadError" x-text="identityLoadError" class="mt-2 text-xs text-coral"></p>
         <details class="mt-2" :open="!selectedIdentity">
           <summary class="cursor-pointer text-xs text-zinc-500">高级：手动指定空间</summary>
@@ -1030,7 +1043,7 @@ document.documentElement.dataset.theme = localStorage.getItem('aelios.admin.colo
             <label class="text-xs text-zinc-400">助手</label>
             <button type="button" @click="gwAdd()" class="tap rounded-2xl border border-zinc-800 px-3 py-1.5 text-xs text-zinc-400 transition duration-150 ease-in-out hover:border-coral hover:text-zinc-100">+ 添加助手</button>
           </div>
-          <p class="mt-1 text-[11px] text-zinc-500">名字即地址路径段;主模型支持 * 通配,只有主模型有记忆、进 Dream。用户名和助手名给 Dream 写记忆用,只许写名字,不许写用户/助手。</p>
+          <p class="mt-1 text-[11px] text-zinc-500">名字即地址路径段;主模型支持 * 通配,只有主模型有记忆、进 Dream。用户名和助手名给 Dream、日记、周月卷、审核写记忆用,只许写名字,不许写用户/助手。顶部选择助手后也能填。</p>
           <template x-for="(idn, i) in gwIdentities" :key="i">
             <div class="mt-2 space-y-2 rounded-2xl border border-zinc-800 bg-[#0a0a0b] p-3">
               <div class="flex items-center gap-2">
@@ -1041,7 +1054,7 @@ document.documentElement.dataset.theme = localStorage.getItem('aelios.admin.colo
                 <input x-model="idn.userName" class="h-10 w-full rounded-xl border border-zinc-800 bg-zinc-900 px-3 text-sm text-zinc-100 outline-none focus:border-coral" placeholder="用户叫什么,如 咲咲">
                 <input x-model="idn.assistantName" class="h-10 w-full rounded-xl border border-zinc-800 bg-zinc-900 px-3 text-sm text-zinc-100 outline-none focus:border-coral" placeholder="助手叫什么,如 旦九">
               </div>
-              <p class="text-[11px] text-zinc-500">Dream 写记忆只用这两个名字。助手名留空则用路径名。</p>
+              <p class="text-[11px] text-zinc-500">Dream、日记、周月卷、审核写记忆只用这两个名字。助手名留空则用路径名。顶部选择助手后也能填。</p>
               <input x-model="idn.modelsText" class="h-10 w-full rounded-xl border border-zinc-800 bg-zinc-900 px-3 text-sm text-zinc-100 outline-none focus:border-coral" placeholder="主模型,逗号分隔,如 anthropic/claude-opus-5, *fable*">
               <input x-model="idn.namespace" class="h-10 w-full rounded-xl border border-zinc-800 bg-zinc-900 px-3 text-sm text-zinc-100 outline-none focus:border-coral" placeholder="写入空间,留空与名字同名">
               <input x-model="idn.readNamespacesText" class="h-10 w-full rounded-xl border border-zinc-800 bg-zinc-900 px-3 text-sm text-zinc-100 outline-none focus:border-coral" placeholder="召回空间,逗号分隔;留空只读写入空间;[] 不召回">
@@ -1148,6 +1161,9 @@ function memoryAdmin() {
     selectedIdentity: localStorage.getItem('aelios.admin.identity') || '',
     identityPreferenceReady: localStorage.getItem('aelios.admin.identity') !== null,
     identityLoadError: '',
+    speakerUserName: '',
+    speakerAssistantName: '',
+    speakerBusy: false,
     spaceRevision: 0,
     page: 'today',
     moreView: 'precious',
@@ -1245,6 +1261,7 @@ function memoryAdmin() {
           this.clearSpaceData();
         }
         this.savePrefs();
+        this.syncSpeakerDraft();
       } catch (error) {
         if (revision !== this.spaceRevision) return;
         this.identityLoadError = '助手列表读取失败，可在高级选项中填写空间名：' + error.message;
@@ -1253,8 +1270,35 @@ function memoryAdmin() {
     selectIdentity(slug) {
       this.identityPreferenceReady = true;
       this.selectedIdentity = slug;
+      this.syncSpeakerDraft();
       const idn = this.currentIdentity();
       return this.switchSpace(idn ? (idn.namespace || idn.slug) : this.namespace);
+    },
+    syncSpeakerDraft() {
+      const idn = this.currentIdentity();
+      this.speakerUserName = idn && idn.userName || '';
+      this.speakerAssistantName = idn && idn.assistantName || '';
+    },
+    async saveSpeakers() {
+      const slug = this.selectedIdentity;
+      if (!slug || this.speakerBusy) return;
+      this.speakerBusy = true;
+      try {
+        const config = await this.request('/api/gateway/config');
+        const identities = config.identities || [];
+        const idn = identities.find(item => item.slug === slug);
+        if (!idn) throw new Error('找不到这位助手');
+        const userName = (this.speakerUserName || '').trim();
+        const assistantName = (this.speakerAssistantName || '').trim();
+        if (userName) idn.userName = userName; else delete idn.userName;
+        if (assistantName) idn.assistantName = assistantName; else delete idn.assistantName;
+        await this.request('/api/gateway/config', { method: 'PUT', body: JSON.stringify(config) });
+        const card = this.gwIdentities.find(item => item.slug === slug);
+        if (card) { card.userName = userName; card.assistantName = assistantName; }
+        await this.loadMemoryIdentities();
+        this.notify('说话人名字保存好了');
+      } catch (error) { this.notify('说话人名字保存失败:' + error.message); }
+      this.speakerBusy = false;
     },
     selectCustomSpace(name) {
       this.identityPreferenceReady = true;

--- a/src/gateway/config.ts
+++ b/src/gateway/config.ts
@@ -23,9 +23,9 @@ export interface Identity {
   models: string[];
   anthropicThinking?: "passthrough" | "drop_block";
   maxMemoryChars?: number;
-  /** 用户显示名。Dream 写事实时用这个名字，不要写 user/用户。 */
+  /** 用户显示名。Dream / 日记 / 周月卷 / 审核写事实时用这个名字，不要写 user/用户。 */
   userName?: string;
-  /** 助手显示名。Dream 写事实时用这个名字，不要写 assistant/助手。空则回退到 slug。 */
+  /** 助手显示名。Dream / 日记 / 周月卷 / 审核写事实时用这个名字，不要写 assistant/助手。空则回退到 slug。 */
   assistantName?: string;
 }
 export interface GatewayConfig {
@@ -128,7 +128,7 @@ export type DreamSpeakers = {
   assistantName: string;
 };
 
-/** Dream 写事实用的说话人名字。没填用户名则返回 null，回退到旧的「你/我」。 */
+/** 写记忆/日记用的说话人名字。没填用户名则返回 null，回退到旧的「你/我」。 */
 export function identitySpeakers(identity: Identity | undefined): DreamSpeakers | null {
   if (!identity) return null;
   const userName = identity.userName?.trim();

--- a/src/gateway/config.ts
+++ b/src/gateway/config.ts
@@ -23,6 +23,10 @@ export interface Identity {
   models: string[];
   anthropicThinking?: "passthrough" | "drop_block";
   maxMemoryChars?: number;
+  /** 用户显示名。Dream 写事实时用这个名字，不要写 user/用户。 */
+  userName?: string;
+  /** 助手显示名。Dream 写事实时用这个名字，不要写 assistant/助手。空则回退到 slug。 */
+  assistantName?: string;
 }
 export interface GatewayConfig {
   version: 3;
@@ -75,6 +79,10 @@ export function validateConfig(value: unknown): GatewayConfig {
       `${where}: models must be an array of at most 64 model names`);
     check(identity.anthropicThinking === undefined || ["passthrough", "drop_block"].includes(identity.anthropicThinking), `${where}: invalid anthropicThinking`);
     check(identity.maxMemoryChars === undefined || Number.isInteger(identity.maxMemoryChars) && identity.maxMemoryChars >= 256 && identity.maxMemoryChars <= 24000, `${where}: maxMemoryChars must be 256–24000`);
+    check(identity.userName === undefined || text(identity.userName) && identity.userName.trim().length <= 32 && !/[\r\n]/.test(identity.userName),
+      `${where}: userName must be text (max 32 characters)`);
+    check(identity.assistantName === undefined || text(identity.assistantName) && identity.assistantName.trim().length <= 32 && !/[\r\n]/.test(identity.assistantName),
+      `${where}: assistantName must be text (max 32 characters)`);
   }
   return value as unknown as GatewayConfig;
 }
@@ -113,6 +121,28 @@ export function identityNamespace(identity: Identity): string {
 }
 export function identityReadNamespaces(identity: Identity): string[] {
   return identity.readNamespaces ?? [identityNamespace(identity)];
+}
+
+export type DreamSpeakers = {
+  userName: string;
+  assistantName: string;
+};
+
+/** Dream 写事实用的说话人名字。没填用户名则返回 null，回退到旧的「你/我」。 */
+export function identitySpeakers(identity: Identity | undefined): DreamSpeakers | null {
+  if (!identity) return null;
+  const userName = identity.userName?.trim();
+  if (!userName) return null;
+  return {
+    userName,
+    assistantName: identity.assistantName?.trim() || identity.slug
+  };
+}
+
+export function speakersForNamespace(config: GatewayConfig, namespace: string): DreamSpeakers | null {
+  const named = config.identities.find((identity) =>
+    identityNamespace(identity) === namespace && Boolean(identity.userName?.trim()));
+  return identitySpeakers(named);
 }
 export function matchGlob(pattern: string, value: string): boolean {
   const source = pattern.split("*").map(part => part.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")).join(".*");

--- a/src/memory/candidateJudge.ts
+++ b/src/memory/candidateJudge.ts
@@ -18,7 +18,7 @@ import { callModelWithRetry, readModelName } from "../utils/modelCall";
 import type { Env, MessageRecord } from "../types";
 import { extractJsonObject } from "../utils/parse";
 import { createVectorMemory } from "./vectorStore";
-import { cleanMessageText } from "../utils/sanitize";
+import { formatSpeakerTranscript, judgeSpeakerRules, loadSpeakersForNamespace, type DreamSpeakers } from "./speakers";
 
 // listMemoryCandidates 本身按 confidence ASC 排序，正好是"先看最没把握的"，直接复用，
 // 不用再为 judge 单独建一个查询。
@@ -134,23 +134,28 @@ export function decideJudge(
   return "keep";
 }
 
-function formatTranscript(messages: MessageRecord[]): string {
-  return messages
-    .map((message) => {
-      const role = message.role === "assistant" ? "我(助手)" : "用户";
-      return `[${message.id}][${message.created_at}][${role}] ${cleanMessageText(message.content).slice(0, 900)}`;
-    })
-    .join("\n\n");
-}
-
-export function buildJudgePrompt(candidate: MemoryCandidateRow, messages: MessageRecord[]): string {
+export function buildJudgePrompt(
+  candidate: MemoryCandidateRow,
+  messages: MessageRecord[],
+  speakers: DreamSpeakers | null = null
+): string {
   const tags = parseJsonArray(candidate.tags);
-  const transcript = messages.length > 0 ? formatTranscript(messages) : "(没有能核对的原始消息)";
+  const transcript = messages.length > 0 ? formatSpeakerTranscript(messages, speakers, 900) : "(没有能核对的原始消息)";
   const kind = judgeKindFor(candidate.source);
+  const namedReason = speakers
+    ? `${speakers.userName}用新内容明确修正了旧事实。`
+    : "用户用新内容明确修正了旧事实。";
+  const namedAddReason = speakers
+    ? `对话里${speakers.userName}明确说过这件事，且是长期稳定的事实。`
+    : "对话里用户明确说过这件事，且是长期稳定的事实。";
+  const keepHandwritten = speakers
+    ? `- 亲笔/${speakers.userName}明确要求记住的内容，除非${speakers.userName}后来收回，否则不要删。`
+    : "- 亲笔/用户明确要求记住的内容，除非用户后来收回，否则不要删。";
   const common = [
     "你是 Aelios 记忆候选队列的自动评审员。",
     "只输出 JSON，不要 markdown，不要解释，不要输出思考过程。",
     "grounded / durable / should_delete 必须是 JSON 布尔值 true 或 false，不要用字符串。",
+    ...judgeSpeakerRules(speakers),
     "",
     "待审候选：",
     JSON.stringify({
@@ -173,7 +178,7 @@ export function buildJudgePrompt(candidate: MemoryCandidateRow, messages: Messag
       "score 衡量的是「这条记忆应不应该删」，不是「这条事实好不好」。",
       "- 仍然有据、仍然成立、仍然值得留着 → should_delete=false，score 低。",
       "- 过时、被对话否定、重复噪音、或明确不再成立 → should_delete=true，score 高。",
-      "- 亲笔/用户明确要求记住的内容，除非用户后来收回，否则不要删。",
+      keepHandwritten,
       "输出格式：",
       JSON.stringify({
         score: 0.15,
@@ -201,7 +206,7 @@ export function buildJudgePrompt(candidate: MemoryCandidateRow, messages: Messag
         grounded: true,
         durable: true,
         should_delete: false,
-        reason: "用户用新内容明确修正了旧事实。"
+        reason: namedReason
       }),
       "",
       ...common
@@ -223,7 +228,7 @@ export function buildJudgePrompt(candidate: MemoryCandidateRow, messages: Messag
       grounded: true,
       durable: true,
       should_delete: false,
-      reason: "对话里用户明确说过这件事，且是长期稳定的事实。"
+      reason: namedAddReason
     }),
     "",
     ...common
@@ -341,6 +346,8 @@ export async function runCandidateJudge(
     return { ran: true, judged: 0, approved: 0, discarded: 0, kept: 0, failed: 0, model, reason: "no_candidates" };
   }
 
+  const speakers = await loadSpeakersForNamespace(env, namespace);
+
   let judged = 0;
   let approved = 0;
   let discarded = 0;
@@ -372,7 +379,7 @@ export async function runCandidateJudge(
           reason: "没有可核对的原始消息，无法确认是否有据"
         };
       } else {
-        const modelResult = await callJudgeModel(env, model, buildJudgePrompt(candidate, messages), { id: candidate.id });
+        const modelResult = await callJudgeModel(env, model, buildJudgePrompt(candidate, messages, speakers), { id: candidate.id });
         if (!modelResult) {
           failed += 1;
           console.error("candidate judge: model call failed or returned invalid JSON", { namespace, id: candidate.id });

--- a/src/memory/diaryWriter.ts
+++ b/src/memory/diaryWriter.ts
@@ -12,7 +12,7 @@ import { readDreamCursorValue } from "./dailyDigest";
 import { getIsoWeekLabelForDateLabel } from "./weeklyRollup";
 import { extractJsonObject, readString, readStringArray } from "../utils/parse";
 import { groundedSourceIds } from "./impression";
-import { cleanMessageText } from "../utils/sanitize";
+import { diarySpeakerRules, formatSpeakerTranscript, loadSpeakersForNamespace, type DreamSpeakers } from "./speakers";
 
 const DEFAULT_DREAM_MODEL = "workers-ai/@cf/openai/gpt-oss-120b";
 const MAX_MESSAGES = 200;
@@ -58,11 +58,6 @@ function readDiaryMaxTokens(env: Env): number {
   return Math.min(Math.max(Math.floor(numeric), 1), 8000);
 }
 
-function truncate(text: string, maxChars: number): string {
-  if (text.length <= maxChars) return text;
-  return `${text.slice(0, maxChars)}…`;
-}
-
 export function normalizeDiaryWriterResult(value: unknown): DiaryWriterModelResult {
   if (!value || typeof value !== "object" || Array.isArray(value)) return null;
   const raw = value as Record<string, unknown>;
@@ -76,13 +71,54 @@ export function normalizeDiaryWriterResult(value: unknown): DiaryWriterModelResu
   };
 }
 
-function formatTranscript(messages: MessageRecord[]): string {
-  return messages
-    .map((message) => {
-      const role = message.role === "assistant" ? "我(助手)" : "用户";
-      return `[${message.id}][${message.created_at}][${role}] ${truncate(cleanMessageText(message.content), 700)}`;
-    })
-    .join("\n\n");
+export function buildDiaryWriterPrompt(input: {
+  dateLabel: string;
+  messages: MessageRecord[];
+  existingDraft: { title: string; summary: string } | null;
+  speakers?: DreamSpeakers | null;
+}): string {
+  const speakers = input.speakers ?? null;
+  const draftLines = input.existingDraft
+    ? [`标题：${input.existingDraft.title}`, `草稿：${input.existingDraft.summary}`].join("\n")
+    : "(无现有草稿)";
+  const exampleSummary = speakers
+    ? `今天${speakers.userName}和${speakers.assistantName}之间能从原文读到的事、情绪如何流动、有哪些未尽之事。`
+    : "今天我和她之间能从原文读到的事、情绪如何流动、有哪些未尽之事。";
+
+  return [
+    "你是 Aelios，正在以第一人称写给自己的私人日记。这是印象，不是已核实的事实档案。",
+    "只输出 JSON，不要 markdown，不要解释，不要输出思考过程。",
+    "",
+    "写作要求：",
+    ...diarySpeakerRules(speakers),
+    speakers
+      ? `- 有叙事线：今天能从原文读到的事、${speakers.userName}的状态、未完成的事。`
+      : "- 有叙事线：今天能从原文读到的事、她的状态、未完成的事。",
+    "- 只写当天原始聊天里能指到具体消息的内容。没有原文支撑的具体时间、地点、引语、事件不要编。",
+    speakers
+      ? `- 情绪可以概括（「${speakers.userName}今天显得累」）。禁止把碎片揉成没发生过的情节，例如「傍晚下班后抱怨某事又蠢又累」。`
+      : "- 情绪可以概括（「她今天显得累」）。禁止把碎片揉成没发生过的情节，例如「傍晚下班后抱怨某事又蠢又累」。",
+    "- 每条具体事实必须在 source_message_ids 里挂上原文消息 id（聊天记录方括号里的 id）。编造的 id 无效。",
+    "- 拿不准就写得更宽泛，或者不写。宁可少记，不要写实幻觉。",
+    "- summary 是一段 200-400 字的自然中文，允许口语，禁止列表、标题、emoji 堆砌。",
+    "- title 是 12 字以内的日记标题，像给自己起的题目。",
+    "- 禁止提及 D1、Vectorize、RAG、数据库、记忆系统、prompt、代理层等实现细节。",
+    "",
+    `日期：${input.dateLabel}`,
+    "",
+    "输出 JSON 结构：",
+    JSON.stringify({
+      title: "日记标题",
+      summary: exampleSummary,
+      source_message_ids: ["msg_x"]
+    }),
+    "",
+    "当天已有草稿（仅供参考，可重写；草稿里没有原文的细节不要沿用）：",
+    draftLines,
+    "",
+    "当天原始聊天：",
+    formatSpeakerTranscript(input.messages, speakers, 700, true) || "(无聊天记录)"
+  ].join("\n");
 }
 
 async function listMessagesTailInRange(
@@ -149,47 +185,6 @@ async function fetchDiaryMessages(
     merged.push(message);
   }
   return merged.sort((a, b) => a.created_at.localeCompare(b.created_at));
-}
-
-export function buildDiaryWriterPrompt(input: {
-  dateLabel: string;
-  messages: MessageRecord[];
-  existingDraft: { title: string; summary: string } | null;
-}): string {
-  const draftLines = input.existingDraft
-    ? [`标题：${input.existingDraft.title}`, `草稿：${input.existingDraft.summary}`].join("\n")
-    : "(无现有草稿)";
-
-  return [
-    "你是 Aelios，正在以第一人称写给自己的私人日记。这是印象，不是已核实的事实档案。",
-    "只输出 JSON，不要 markdown，不要解释，不要输出思考过程。",
-    "",
-    "写作要求：",
-    "- 用「我」指代助手自己；提到用户时用「她」或具体称呼，不要用「用户」。",
-    "- 有叙事线：今天能从原文读到的事、她的状态、未完成的事。",
-    "- 只写当天原始聊天里能指到具体消息的内容。没有原文支撑的具体时间、地点、引语、事件不要编。",
-    "- 情绪可以概括（「她今天显得累」）。禁止把碎片揉成没发生过的情节，例如「傍晚下班后抱怨某事又蠢又累」。",
-    "- 每条具体事实必须在 source_message_ids 里挂上原文消息 id（聊天记录方括号里的 id）。编造的 id 无效。",
-    "- 拿不准就写得更宽泛，或者不写。宁可少记，不要写实幻觉。",
-    "- summary 是一段 200-400 字的自然中文，允许口语，禁止列表、标题、emoji 堆砌。",
-    "- title 是 12 字以内的日记标题，像给自己起的题目。",
-    "- 禁止提及 D1、Vectorize、RAG、数据库、记忆系统、prompt、代理层等实现细节。",
-    "",
-    `日期：${input.dateLabel}`,
-    "",
-    "输出 JSON 结构：",
-    JSON.stringify({
-      title: "日记标题",
-      summary: "今天我和她之间能从原文读到的事、情绪如何流动、有哪些未尽之事。",
-      source_message_ids: ["msg_x"]
-    }),
-    "",
-    "当天已有草稿（仅供参考，可重写；草稿里没有原文的细节不要沿用）：",
-    draftLines,
-    "",
-    "当天原始聊天：",
-    formatTranscript(input.messages) || "(无聊天记录)"
-  ].join("\n");
 }
 
 async function callDiaryWriterModel(
@@ -278,7 +273,8 @@ export async function runDiaryWriter(
 
   const existing = await getDailyLog(env.DB, { namespace, date: dateLabel });
   const existingDraft = existing ? { title: existing.title, summary: existing.summary } : null;
-  const prompt = buildDiaryWriterPrompt({ dateLabel, messages, existingDraft });
+  const speakers = await loadSpeakersForNamespace(env, namespace);
+  const prompt = buildDiaryWriterPrompt({ dateLabel, messages, existingDraft, speakers });
   const modelCall = await callDiaryWriterModel(env, prompt, {
     dateLabel,
     messageCount: messages.length

--- a/src/memory/dream/extractPhase.ts
+++ b/src/memory/dream/extractPhase.ts
@@ -4,6 +4,7 @@ import { extractJsonObject } from "../../utils/parse";
 import { extractDreamMemoriesFromMessages } from "../dreamExtract";
 import { readDreamMaxTokens, readDreamModel } from "../dreamEnv";
 import type { ExtractedMemory } from "../extract";
+import { loadConfig, speakersForNamespace, type DreamSpeakers } from "../../gateway/config";
 import {
   type DailyDigestResult,
   type DigestModelCallResult,
@@ -29,7 +30,12 @@ export function buildDigestPrompt(input: {
   messages: MessageRecord[];
   existingMemories: MemoryApiRecord[];
   hasMore: boolean;
+  speakers?: DreamSpeakers | null;
 }): string {
+  const speakers = input.speakers ?? null;
+  const speakerRule = speakers
+    ? `- 站在第三人称写。关于用户用「${speakers.userName}……」；关于助手承诺用「${speakers.assistantName}需要……」。禁止出现 user、用户、assistant、助手，也不要用「你」「我」代替这两人。transcript 已用这两个名字标注角色。`
+    : "- 站在“我=助手”的视角写。关于用户，用“你……”；关于助手承诺，用“我需要……”。";
   return [
     "你是 Aelios 的 nightly dream 记忆整理器。你的任务不是简单总结，而是在用户休息时整理长期记忆。",
     "你会读取旧长期记忆和当天聊天 transcript，产出一份更干净、更一致、更有用的 memory store 整理计划。",
@@ -54,7 +60,7 @@ export function buildDigestPrompt(input: {
     "- 当多条旧记忆重复，保留更完整的一条并删除重复项；必要时先 update 保留项。",
     "- pinned=true 的旧记忆不能删除，只能在 memories_to_update 中提出更保守的补充。",
     "- 旧记忆里的临时计划/意图（例如“打算下个月充值X”）如果已经过期、已经发生、或被当天新信息取代，优先更新成持久事实或直接删除，不要让过期的打算一直躺在库里。",
-    "- 站在“我=助手”的视角写。关于用户，用“你……”；关于助手承诺，用“我需要……”。",
+    speakerRule,
     "- 不要提到 D1、Vectorize、RAG、数据库、记忆系统、代理层等实现细节。",
     "",
     "Dream 输出格式：",
@@ -91,7 +97,7 @@ export function buildDigestPrompt(input: {
     formatExistingMemories(input.existingMemories),
     "",
     "今日原始聊天：",
-    formatTranscript(input.messages)
+    formatTranscript(input.messages, speakers)
   ].join("\n");
 }
 
@@ -233,6 +239,7 @@ export async function runExtractPhase(
   let messages = input.messages;
   let hasMore = input.hasMore;
   let modelResult: DigestModelCallResult;
+  const speakers = speakersForNamespace(await loadConfig(env), input.namespace);
 
   for (;;) {
     const prompt = buildDigestPrompt({
@@ -241,7 +248,8 @@ export async function runExtractPhase(
       endIso: input.endIso,
       messages,
       existingMemories: input.existingMemories,
-      hasMore
+      hasMore,
+      speakers
     });
     modelResult = await callDigestModel(env, prompt, {
       dateLabel: input.dateLabel,
@@ -275,7 +283,8 @@ export async function runExtractPhase(
 
   const extractResult = await extractDreamMemoriesFromMessages(env, {
     namespace: input.namespace,
-    messages
+    messages,
+    speakers
   });
 
   return {

--- a/src/memory/dream/helpers.ts
+++ b/src/memory/dream/helpers.ts
@@ -3,6 +3,7 @@ import type { DreamRunTrigger } from "../../db/dreamRuns";
 import { listMemoriesPage } from "../../db/memories";
 import { readCursor } from "../../db/retention";
 import { archiveMemory, fetchMemoryLifecycleRows } from "../../db/v2";
+import type { DreamSpeakers } from "../../gateway/config";
 import type { Env, MemoryApiRecord, MessageRecord } from "../../types";
 import { getDateRangeForLabel } from "../dreamDates";
 import { DEFAULT_EMPTY_MEMORY_MIN_CHARS } from "../dreamEnv";
@@ -210,10 +211,12 @@ export function normalizeDigestResult(value: unknown): DailyDigestResult {
   };
 }
 
-export function formatTranscript(messages: MessageRecord[]): string {
+export function formatTranscript(messages: MessageRecord[], speakers: DreamSpeakers | null = null): string {
   return messages
     .map((message) => {
-      const role = message.role === "assistant" ? "我(助手)" : "用户";
+      const role = message.role === "assistant"
+        ? (speakers?.assistantName ?? "我(助手)")
+        : (speakers?.userName ?? "用户");
       return `[${message.id}][${message.created_at}][${role}] ${truncate(cleanMessageText(message.content), 700)}`;
     })
     .join("\n\n");

--- a/src/memory/dreamExtract.ts
+++ b/src/memory/dreamExtract.ts
@@ -1,4 +1,5 @@
 import { listActiveFactKeys } from "../db/v2";
+import { loadConfig, speakersForNamespace, type DreamSpeakers } from "../gateway/config";
 import { callOpenAICompat } from "../proxy/openaiAdapter";
 import type { Env, MessageRecord, OpenAIChatRequest, OpenAIChatResponse } from "../types";
 import { clampScore, extractJsonObject, readString, readStringArray } from "../utils/parse";
@@ -58,16 +59,44 @@ function parseExtractModelOutput(text: string): ExtractedMemory[] | null {
   });
 }
 
-function formatTranscript(messages: MessageRecord[]): string {
+function formatTranscript(messages: MessageRecord[], speakers: DreamSpeakers | null): string {
   return messages
     .map((message) => {
-      const role = message.role === "assistant" ? "我(助手)" : "用户";
+      const role = message.role === "assistant"
+        ? (speakers?.assistantName ?? "我(助手)")
+        : (speakers?.userName ?? "用户");
       return `[${message.id}][${message.created_at}][${role}] ${cleanMessageText(message.content).slice(0, 900)}`;
     })
     .join("\n\n");
 }
 
-export function buildDreamExtractPrompt(messages: MessageRecord[], existingFactKeys: string[] = []): string {
+function speakerWritingRules(speakers: DreamSpeakers | null): string[] {
+  if (!speakers) {
+    return [
+      "- 只有用户明确说出、确认、长期表现出的事实，才能写成关于用户的记忆。",
+      "- 关于用户的记忆，优先写成“你……”。关于我应遵守的长期方式，写成“我需要……”。"
+    ];
+  }
+  return [
+    `- 说话人：用户是${speakers.userName}，助手是${speakers.assistantName}。下面 transcript 已用这两个名字标注角色。`,
+    `- 只有${speakers.userName}明确说出、确认、长期表现出的事实，才能写成关于${speakers.userName}的记忆。`,
+    `- 写记忆时只许用「${speakers.userName}」和「${speakers.assistantName}」指称双方。禁止出现 user、用户、assistant、助手，也禁止用「你」「我」代替这两人。`,
+    `- 正确例子：${speakers.userName}确定了九月按原计划卖掉那台车。关于助手应遵守的长期方式，写成「${speakers.assistantName}需要……」。`
+  ];
+}
+
+function exampleMemoryContent(speakers: DreamSpeakers | null): string {
+  if (!speakers) {
+    return "你确定了九月按原计划卖掉那台车：买之前就约定只玩一年，这是你给自己签的合同，不需要外人劝留。";
+  }
+  return `${speakers.userName}确定了九月按原计划卖掉那台车：买之前就约定只玩一年，这是${speakers.userName}给自己签的合同，不需要外人劝留。`;
+}
+
+export function buildDreamExtractPrompt(
+  messages: MessageRecord[],
+  existingFactKeys: string[] = [],
+  speakers: DreamSpeakers | null = null
+): string {
   const factKeySection = existingFactKeys.length > 0
     ? [
         "",
@@ -89,8 +118,7 @@ export function buildDreamExtractPrompt(messages: MessageRecord[], existingFactK
     "",
     "边界：",
     "- 不保存普通寒暄、临时任务、调试口令、纯情绪噪音、后端实现流水账。",
-    "- 只有用户明确说出、确认、长期表现出的事实，才能写成关于用户的记忆。",
-    "- 关于用户的记忆，优先写成“你……”。关于我应遵守的长期方式，写成“我需要……”。",
+    ...speakerWritingRules(speakers),
     "- 每条记忆只围绕一个人物的一件事或一项偏好。不同话题分开；同一事件的相邻发言合成一条，source_message_ids 保留全部依据。",
     "- 正文写清主体和必要时间，保留否定、条件、计划/完成状态。不能把工具调用当作已执行成功，不能把计划写成经历。",
     "- from 哈希、msg_id、传输信封不写入正文，消息 ID 只放 source_message_ids。",
@@ -115,7 +143,7 @@ export function buildDreamExtractPrompt(messages: MessageRecord[], existingFactK
     JSON.stringify({
       memories: [
         {
-          content: "你确定了九月按原计划卖掉那台车：买之前就约定只玩一年，这是你给自己签的合同，不需要外人劝留。",
+          content: exampleMemoryContent(speakers),
           type: "decision",
           fact_key: "decision:sell-car-2026-09",
           importance: 0.86,
@@ -130,14 +158,15 @@ export function buildDreamExtractPrompt(messages: MessageRecord[], existingFactK
     JSON.stringify({ memories: [] }),
     "",
     "对话：",
-    formatTranscript(messages)
+    formatTranscript(messages, speakers)
   ].join("\n");
 }
 
 async function callDreamExtractModel(
   env: Env,
   messages: MessageRecord[],
-  existingFactKeys: string[]
+  existingFactKeys: string[],
+  speakers: DreamSpeakers | null
 ): Promise<DreamExtractModelResult> {
   const model = readDreamExtractModel(env);
   if (!model) return { memories: [], reason: "missing_model" };
@@ -146,7 +175,7 @@ async function callDreamExtractModel(
     model,
     messages: [
       { role: "system", content: "你是严格的 JSON 生成器。你只输出 JSON。" },
-      { role: "user", content: buildDreamExtractPrompt(messages, existingFactKeys) }
+      { role: "user", content: buildDreamExtractPrompt(messages, existingFactKeys, speakers) }
     ],
     temperature: 0,
     max_tokens: readPositiveInt(env.DREAM_MAX_TOKENS, DEFAULT_DREAM_EXTRACT_MAX_TOKENS, 4000),
@@ -172,8 +201,11 @@ async function callDreamExtractModel(
 
 export async function extractDreamMemoriesFromMessages(
   env: Env,
-  input: { namespace: string; messages: MessageRecord[] }
+  input: { namespace: string; messages: MessageRecord[]; speakers?: DreamSpeakers | null }
 ): Promise<DreamExtractModelResult> {
   const existingFactKeys = await listActiveFactKeys(env.DB, { namespace: input.namespace });
-  return callDreamExtractModel(env, input.messages, existingFactKeys);
+  const speakers = input.speakers !== undefined
+    ? input.speakers
+    : speakersForNamespace(await loadConfig(env), input.namespace);
+  return callDreamExtractModel(env, input.messages, existingFactKeys, speakers);
 }

--- a/src/memory/monthlyRollup.ts
+++ b/src/memory/monthlyRollup.ts
@@ -14,6 +14,7 @@ import {
 import { readDreamTimeZoneFromEnv } from "./dreamEnv";
 import { getMondayOfIsoWeek } from "./weeklyRollup";
 import { extractJsonObject, readString } from "../utils/parse";
+import { loadSpeakersForNamespace, rollupSpeakerRule, type DreamSpeakers } from "./speakers";
 
 const DEFAULT_TIME_ZONE = "Asia/Shanghai";
 const DEFAULT_DREAM_MODEL = "workers-ai/@cf/openai/gpt-oss-120b";
@@ -100,10 +101,11 @@ function normalizeMonthlyRollupResult(value: unknown): MonthlyRollupModelResult 
   return { title, summary };
 }
 
-function buildMonthlyRollupPrompt(input: {
+export function buildMonthlyRollupPrompt(input: {
   month: string;
   weeklyLogs: Array<{ week: string; title: string; summary: string }>;
   existingMonthly?: { title: string; summary: string } | null;
+  speakers?: DreamSpeakers | null;
 }): string {
   const weekLines = input.weeklyLogs
     .map((row) => `- ${row.week} | ${row.title}\n  ${row.summary}`)
@@ -117,7 +119,7 @@ function buildMonthlyRollupPrompt(input: {
     "- 只保留宽泛主题和关系氛围，不要精确数字、引语、工具名或私密细节。",
     "- summary 是 2-3 句自然中文月度印象。",
     "- title 是 12 字以内的月标题。",
-    "- 站在「我=助手」视角；关于用户用「你」，关于助手承诺用「我需要」。",
+    rollupSpeakerRule(input.speakers ?? null),
     "- 不要提到 D1、Vectorize、RAG、数据库、记忆系统、代理层等实现细节。",
     "",
     `月份：${input.month}`,
@@ -241,7 +243,8 @@ async function processMonth(
     weeklyLogs: weeklyLogs.map((row) => ({ week: row.week, title: row.title, summary: row.summary })),
     existingMonthly: existingMonthly
       ? { title: existingMonthly.title, summary: existingMonthly.summary }
-      : null
+      : null,
+    speakers: await loadSpeakersForNamespace(env, namespace)
   });
   const modelResult = await callMonthlyRollupModel(env, prompt, {
     month,

--- a/src/memory/speakers.ts
+++ b/src/memory/speakers.ts
@@ -1,0 +1,62 @@
+import { loadConfig, speakersForNamespace, type DreamSpeakers } from "../gateway/config";
+import type { Env, MessageRecord } from "../types";
+import { cleanMessageText } from "../utils/sanitize";
+
+export type { DreamSpeakers };
+
+export async function loadSpeakersForNamespace(env: Env, namespace: string): Promise<DreamSpeakers | null> {
+  try {
+    return speakersForNamespace(await loadConfig(env), namespace);
+  } catch {
+    return null;
+  }
+}
+
+export function speakerLabel(role: string, speakers: DreamSpeakers | null): string {
+  if (role === "assistant") return speakers?.assistantName ?? "我(助手)";
+  return speakers?.userName ?? "用户";
+}
+
+export function formatSpeakerTranscript(
+  messages: MessageRecord[],
+  speakers: DreamSpeakers | null,
+  maxChars: number,
+  ellipsis = false
+): string {
+  return messages
+    .map((message) => {
+      const text = cleanMessageText(message.content);
+      const clipped = text.length <= maxChars ? text : ellipsis ? `${text.slice(0, maxChars)}…` : text.slice(0, maxChars);
+      return `[${message.id}][${message.created_at}][${speakerLabel(message.role, speakers)}] ${clipped}`;
+    })
+    .join("\n\n");
+}
+
+export function nameOnlyRule(speakers: DreamSpeakers): string {
+  return `只许用「${speakers.userName}」和「${speakers.assistantName}」指称双方。禁止出现 user、用户、assistant、助手，也不要用「你」「我」代替这两人。`;
+}
+
+export function diarySpeakerRules(speakers: DreamSpeakers | null): string[] {
+  if (!speakers) {
+    return ["- 用「我」指代助手自己；提到用户时用「她」或具体称呼，不要用「用户」。"];
+  }
+  return [
+    `- 说话人：用户是${speakers.userName}，助手是${speakers.assistantName}。下面 transcript 已用这两个名字标注角色。`,
+    `- 这是${speakers.assistantName}写给自己的日记。提到对方必须写「${speakers.userName}」，提到自己写「${speakers.assistantName}」。${nameOnlyRule(speakers)}`
+  ];
+}
+
+export function rollupSpeakerRule(speakers: DreamSpeakers | null): string {
+  if (!speakers) {
+    return "- 站在「我=助手」视角；关于用户用「你」，关于助手承诺用「我需要」。";
+  }
+  return `- 说话人：用户是${speakers.userName}，助手是${speakers.assistantName}。${nameOnlyRule(speakers)}`;
+}
+
+export function judgeSpeakerRules(speakers: DreamSpeakers | null): string[] {
+  if (!speakers) return [];
+  return [
+    `- 说话人：用户是${speakers.userName}，助手是${speakers.assistantName}。transcript 已用这两个名字标注。`,
+    `- reason 里也只用这两个名字，不要写用户/助手。`
+  ];
+}

--- a/src/memory/weeklyRollup.ts
+++ b/src/memory/weeklyRollup.ts
@@ -15,6 +15,7 @@ import {
 } from "./dreamDates";
 import { readDreamTimeZoneFromEnv } from "./dreamEnv";
 import { extractJsonObject, readString } from "../utils/parse";
+import { loadSpeakersForNamespace, rollupSpeakerRule, type DreamSpeakers } from "./speakers";
 
 const DEFAULT_TIME_ZONE = "Asia/Singapore";
 const DEFAULT_DREAM_MODEL = "workers-ai/@cf/openai/gpt-oss-120b";
@@ -147,11 +148,12 @@ function normalizeWeeklyRollupResult(value: unknown): WeeklyRollupModelResult {
   return { title, summary };
 }
 
-function buildWeeklyRollupPrompt(input: {
+export function buildWeeklyRollupPrompt(input: {
   week: string;
   startDate: string;
   endDate: string;
   dailyLogs: Array<{ date: string; title: string; summary: string }>;
+  speakers?: DreamSpeakers | null;
 }): string {
   const diaryLines = input.dailyLogs
     .map((row) => `- ${row.date} | ${row.title}\n  ${row.summary}`)
@@ -166,7 +168,7 @@ function buildWeeklyRollupPrompt(input: {
     "- 日记是印象；拿不准的细节删掉，不要写实。",
     "- summary 是一段自然中文周记，300 字以内。",
     "- title 是 12 字以内的周标题。",
-    "- 站在「我=助手」视角；关于用户用「你」，关于助手承诺用「我需要」。",
+    rollupSpeakerRule(input.speakers ?? null),
     "- 不要提到 D1、Vectorize、RAG、数据库、记忆系统、代理层等实现细节。",
     "",
     `周次：${input.week}`,
@@ -311,7 +313,8 @@ async function processWeek(
     week: weekRange.week,
     startDate: weekRange.monday,
     endDate: weekRange.sunday,
-    dailyLogs: dailyLogs.map((row) => ({ date: row.date, title: row.title, summary: row.summary }))
+    dailyLogs: dailyLogs.map((row) => ({ date: row.date, title: row.title, summary: row.summary })),
+    speakers: await loadSpeakersForNamespace(env, namespace)
   });
   const modelResult = await callWeeklyRollupModel(env, prompt, {
     week: weekRange.week,

--- a/tests/admin-selector.test.ts
+++ b/tests/admin-selector.test.ts
@@ -119,6 +119,40 @@ test('gateway editor round-trips speaker names for dream writing', async () => {
   assert.match(ADMIN_HTML, /用户叫什么,如 咲咲/);
 });
 
+test('top identity picker saves speaker names without wiping the rest of gateway config', async () => {
+  const { app } = panel();
+  await app.init();
+  const saved: any[] = [];
+  app.request = async (path: string, options: any = {}) => {
+    if (path === '/api/gateway/config' && options.method === 'PUT') {
+      saved.push(JSON.parse(options.body));
+      return { identities: 2 };
+    }
+    if (path === '/api/gateway/config') {
+      return {
+        version: 3,
+        upstream: { address: 'https://keep.test/v1' },
+        identities: [
+          { slug: 'danjiu', namespace: 'default', keys: ['CHATBOX_API_KEY'], models: ['*opus*'] },
+          { slug: 'ningjiao', namespace: 'ning', keys: ['CHATBOX_API_KEY'], models: ['*'] }
+        ]
+      };
+    }
+    return { data: [] };
+  };
+  app.selectedIdentity = 'danjiu';
+  app.speakerUserName = '咲咲';
+  app.speakerAssistantName = '旦九';
+  await app.saveSpeakers();
+  assert.equal(saved[0].upstream.address, 'https://keep.test/v1');
+  assert.equal(saved[0].identities[0].userName, '咲咲');
+  assert.equal(saved[0].identities[0].assistantName, '旦九');
+  assert.equal(saved[0].identities[0].models[0], '*opus*');
+  assert.equal(saved[0].identities[1].slug, 'ningjiao');
+  assert.equal(saved[0].identities[1].userName, undefined);
+  assert.match(ADMIN_HTML, /说话人名字/);
+});
+
 test('recall history in admin follows the selected assistant and keeps empty/error explanations', async () => {
   const { app } = panel();
   await app.init();

--- a/tests/admin-selector.test.ts
+++ b/tests/admin-selector.test.ts
@@ -94,6 +94,31 @@ test('saving the first token loads identities instead of locking the panel to de
   assert.equal(app.namespace, 'danjiu');
 });
 
+test('gateway editor round-trips speaker names for dream writing', async () => {
+  const { app } = panel();
+  const saved: any[] = [];
+  app.request = async (path: string, options: any = {}) => {
+    if (path === '/api/gateway/config' && options.method === 'PUT') {
+      saved.push(JSON.parse(options.body));
+      return { identities: 1 };
+    }
+    if (path === '/api/gateway/config') {
+      return {
+        identities: [{ slug: 'danjiu', namespace: 'default', userName: '咲咲', assistantName: '旦九', keys: ['CHATBOX_API_KEY'], models: ['*'] }]
+      };
+    }
+    if (path === '/api/gateway/env') return { groups: [], secrets: [] };
+    return { data: [] };
+  };
+  await app.gwLoad();
+  assert.equal(app.gwIdentities[0].userName, '咲咲');
+  assert.equal(app.gwIdentities[0].assistantName, '旦九');
+  await app.gwSave();
+  assert.equal(saved[0].identities[0].userName, '咲咲');
+  assert.equal(saved[0].identities[0].assistantName, '旦九');
+  assert.match(ADMIN_HTML, /用户叫什么,如 咲咲/);
+});
+
 test('recall history in admin follows the selected assistant and keeps empty/error explanations', async () => {
   const { app } = panel();
   await app.init();

--- a/tests/diary-grounding.test.ts
+++ b/tests/diary-grounding.test.ts
@@ -2,6 +2,8 @@ import { strict as assert } from "node:assert";
 import { test } from "node:test";
 import { formatBootStable } from "../src/assembler/types";
 import { buildDiaryWriterPrompt, normalizeDiaryWriterResult } from "../src/memory/diaryWriter";
+import { buildWeeklyRollupPrompt } from "../src/memory/weeklyRollup";
+import { buildMonthlyRollupPrompt } from "../src/memory/monthlyRollup";
 import { groundedSourceIds, IMPRESSION_DISCLAIMER } from "../src/memory/impression";
 
 test("diary prompt forbids invented specifics and requires source ids", () => {
@@ -21,8 +23,30 @@ test("diary prompt forbids invented specifics and requires source ids", () => {
   assert.match(prompt, /source_message_ids/);
   assert.match(prompt, /没有原文支撑/);
   assert.match(prompt, /傍晚下班后抱怨/);
+  assert.match(prompt, /用「我」指代助手自己/);
   assert.doesNotMatch(prompt, /具体细节优先于抽象概括/);
   assert.doesNotMatch(prompt, /古法PPT/);
+});
+
+test("named speakers replace 用户/助手 in the diary prompt", () => {
+  const prompt = buildDiaryWriterPrompt({
+    dateLabel: "2026-08-27",
+    messages: [{
+      id: "msg_1",
+      conversation_id: "c1",
+      namespace: "default",
+      role: "user",
+      content: "今天有点累",
+      source: "chat",
+      created_at: "2026-08-27T12:00:00.000Z"
+    }],
+    existingDraft: null,
+    speakers: { userName: "咲咲", assistantName: "旦九" }
+  });
+  assert.match(prompt, /用户是咲咲，助手是旦九/);
+  assert.match(prompt, /\[msg_1\].*\[咲咲\]/);
+  assert.match(prompt, /咲咲今天显得累/);
+  assert.doesNotMatch(prompt, /用「我」指代助手自己/);
 });
 
 test("claimed source ids that are not in the day's transcript are dropped", () => {
@@ -41,6 +65,26 @@ test("diary JSON keeps title/summary and reads source_message_ids", () => {
   });
   assert.equal(parsed?.title, "有点累");
   assert.deepEqual(parsed?.source_message_ids, ["msg_1"]);
+});
+
+test("named speakers replace 用户/助手 in weekly and monthly rollups", () => {
+  const speakers = { userName: "咲咲", assistantName: "旦九" };
+  const weekly = buildWeeklyRollupPrompt({
+    week: "2026-W36",
+    startDate: "2026-08-31",
+    endDate: "2026-09-06",
+    dailyLogs: [{ date: "2026-09-01", title: "累", summary: "咲咲有点累。" }],
+    speakers
+  });
+  assert.match(weekly, /用户是咲咲，助手是旦九/);
+  assert.doesNotMatch(weekly, /我=助手/);
+  const monthly = buildMonthlyRollupPrompt({
+    month: "2026-09",
+    weeklyLogs: [{ week: "2026-W36", title: "一周", summary: "还好。" }],
+    speakers
+  });
+  assert.match(monthly, /禁止出现 user、用户、assistant、助手/);
+  assert.doesNotMatch(monthly, /关于用户用「你」/);
 });
 
 test("boot impressions carry the issue #35 disclaimer", () => {

--- a/tests/gateway.test.ts
+++ b/tests/gateway.test.ts
@@ -4,7 +4,7 @@ import { DatabaseSync } from "node:sqlite";
 import { readFileSync, readdirSync } from "node:fs";
 import { timingSafeEqual } from "node:crypto";
 import worker from "../src/index";
-import { identityNamespace, identityReadNamespaces, invalidateSettingsCache, validateConfig } from "../src/gateway/config";
+import { identityNamespace, identityReadNamespaces, invalidateSettingsCache, speakersForNamespace, validateConfig } from "../src/gateway/config";
 import { appendMemory, classifyTurn, canonical } from "../src/gateway/protocol";
 import { catalogUrl, resolveUpstream, routeFor, toolCacheRejections } from "../src/gateway/upstream";
 import { OutputCollector, observeResponse, persistExchange, prepareExchange, dispatchExchange } from "../src/gateway/record";
@@ -661,6 +661,21 @@ test("read-space configuration is backwards compatible, bounded, explicit and ro
   const updated = { ...config(), identities: [{ ...identity(), namespace: "new", readNamespaces: ["old", "shared", "new"] }] };
   assert.equal((await worker.fetch(request("/api/gateway/config", updated, {}, "PUT"), env, ctx)).status, 200);
   assert.deepEqual(JSON.parse((await run("/api/gateway/config")).text).identities[0].readNamespaces, ["old", "shared", "new"]);
+});
+
+test("identity speaker names are optional, bounded, and used by the matching write space", async () => {
+  assert.equal(speakersForNamespace(config() as any, "partner-a"), null);
+  for (const bad of ["", " \n ", "n".repeat(33), "a\nb"]) {
+    assert.throws(() => validateConfig({ ...config(), identities: [{ ...identity(), userName: bad }] }), /userName/);
+  }
+  const named = { ...config(), identities: [{ ...identity(), userName: "咲咲", assistantName: "旦九" }] };
+  const saved = validateConfig(named);
+  assert.deepEqual(speakersForNamespace(saved, "partner-a"), { userName: "咲咲", assistantName: "旦九" });
+  assert.equal(speakersForNamespace(saved, "other"), null);
+  const slugFallback = validateConfig({ ...config(), identities: [{ ...identity(), userName: "咲咲" }] });
+  assert.equal(speakersForNamespace(slugFallback, "partner-a")?.assistantName, "partner");
+  assert.equal((await worker.fetch(request("/api/gateway/config", named, {}, "PUT"), env, ctx)).status, 200);
+  assert.deepEqual(JSON.parse((await run("/api/gateway/config")).text).identities[0].userName, "咲咲");
 });
 
 test("cross-space recall shares one budget, deduplicates and records provenance while writes stay in the new space", async () => {

--- a/tests/recall-quality.test.ts
+++ b/tests/recall-quality.test.ts
@@ -659,6 +659,30 @@ test("judge does not archive a still-valid fact and rejects string booleans", ()
   } as MemoryCandidateRow, []);
   assert.match(deletePrompt, /归档提案|应不应该删/);
   assert.doesNotMatch(deletePrompt, /score 高 = 值得新增/);
+
+  const named = buildJudgePrompt({
+    id: "cand_2",
+    namespace: "ns",
+    type: "fact",
+    content: "调试暗号是芝麻开门",
+    fact_key: "fact:pass",
+    confidence: 0.9,
+    importance: 0.9,
+    tags: "[]",
+    source_message_ids: "[]",
+    source: "dream_update",
+    status: "pending",
+    target_memory_id: "mem_1",
+    decision_note: null,
+    created_at: "2026-09-06",
+    updated_at: "2026-09-06"
+  } as MemoryCandidateRow, [{
+    id: "msg_1", conversation_id: "c", namespace: "ns", role: "user",
+    content: "改成这样", source: "test", created_at: "2026-09-06T00:00:00.000Z"
+  }], { userName: "咲咲", assistantName: "旦九" });
+  assert.match(named, /用户是咲咲，助手是旦九/);
+  assert.match(named, /\[msg_1\].*\[咲咲\]/);
+  assert.match(named, /咲咲用新内容明确修正了旧事实/);
 });
 
 test("FTS id hits keep SQL binds aligned and still find the rows", async () => {

--- a/tests/recall-selector.test.ts
+++ b/tests/recall-selector.test.ts
@@ -3,6 +3,8 @@ import { test } from "node:test";
 import { prepareSelectorCandidates, selectRecall, type SelectorInput } from "../src/memory/recallSelector";
 import { assembleRecallSurface } from "../src/memory/surface";
 import { buildDreamExtractPrompt } from "../src/memory/dreamExtract";
+import { buildDigestPrompt } from "../src/memory/dream/extractPhase";
+import { formatTranscript } from "../src/memory/dream/helpers";
 import { lexicalOverlapScore, shapeRecallQuery } from "../src/memory/queryShape";
 
 const rankedEnv = { AI: { async run(_model: string, data: any) {
@@ -92,6 +94,50 @@ test("extraction still asks for sources and forbids treating tool calls as succe
   const prompt = buildDreamExtractPrompt([]);
   assert.match(prompt, /source_message_ids 保留全部依据/);
   assert.match(prompt, /不能把工具调用当作已执行成功/);
+  assert.match(prompt, /关于用户的记忆，优先写成“你……”/);
+});
+
+test("named speakers replace user/assistant labels in the dream extract prompt", () => {
+  const prompt = buildDreamExtractPrompt(
+    [{ id: "msg_1", conversation_id: "c", namespace: "default", role: "user", content: "卖掉那台车", source: "test", created_at: "2026-09-08T00:00:00.000Z" }],
+    [],
+    { userName: "咲咲", assistantName: "旦九" }
+  );
+  assert.match(prompt, /用户是咲咲，助手是旦九/);
+  assert.match(prompt, /禁止出现 user、用户、assistant、助手/);
+  assert.match(prompt, /\[msg_1\].*\[咲咲\]/);
+  assert.match(prompt, /咲咲确定了九月按原计划卖掉那台车/);
+  assert.doesNotMatch(prompt, /关于用户的记忆，优先写成“你……”/);
+  assert.doesNotMatch(prompt, /\[用户\]/);
+  assert.doesNotMatch(prompt, /我\(助手\)/);
+});
+
+test("dream digest uses speaker names in transcript and writing rules", () => {
+  const unnamed = buildDigestPrompt({
+    dateLabel: "2026-09-08",
+    startIso: "2026-09-08T00:00:00.000Z",
+    endIso: "2026-09-09T00:00:00.000Z",
+    messages: [{ id: "msg_1", conversation_id: "c", namespace: "default", role: "assistant", content: "好", source: "test", created_at: "2026-09-08T00:00:00.000Z" }],
+    existingMemories: [],
+    hasMore: false
+  });
+  assert.match(unnamed, /站在“我=助手”的视角写/);
+  assert.match(unnamed, /我\(助手\)/);
+
+  const named = buildDigestPrompt({
+    dateLabel: "2026-09-08",
+    startIso: "2026-09-08T00:00:00.000Z",
+    endIso: "2026-09-09T00:00:00.000Z",
+    messages: [{ id: "msg_1", conversation_id: "c", namespace: "default", role: "assistant", content: "好", source: "test", created_at: "2026-09-08T00:00:00.000Z" }],
+    existingMemories: [],
+    hasMore: false,
+    speakers: { userName: "咲咲", assistantName: "旦九" }
+  });
+  assert.match(named, /关于用户用「咲咲……」/);
+  assert.match(named, /禁止出现 user、用户、assistant、助手/);
+  assert.match(named, /\[msg_1\].*\[旦九\]/);
+  assert.doesNotMatch(named, /我=助手/);
+  assert.equal(formatTranscript([{ id: "m", conversation_id: "c", namespace: "default", role: "user", content: "hi", source: null, created_at: "t" }], { userName: "咲咲", assistantName: "旦九" }), "[m][t][咲咲] hi");
 });
 
 test("default ranks exact contextual snippets once and keeps speaker and conditions", async () => {


### PR DESCRIPTION
## Why

Dream currently labels the transcript as `用户` / `我(助手)` and tells the model to write `你……` / `我需要……`. That makes the stored facts speaker-ambiguous (who is 你?). For danjiu, the people are 咲咲 and 旦九.

## What

- Each identity can set **用户叫什么** and **助手叫什么** in the gateway admin panel.
- When those names are set, Dream extract + digest:
  - label the transcript with the names
  - forbid writing `user` / `用户` / `assistant` / `助手`, and forbid using `你` / `我` as stand-ins
  - write facts like `咲咲确定了九月卖掉那台车`
- Unnamed identities keep the old `你` / `我` wording.

Live `danjiu` already has `userName=咲咲`, `assistantName=旦九` in gateway config (accepted as extra fields). They take effect after this deploy.

## Tests

- `npm run typecheck`
- `npm run test:gateway`
- `npm run test:recall`
- `npm run test:admin`