### PR TITLE
fix(admin): use generic names in speaker-name examples

### DIFF
--- a/src/api/admin/ui.ts
+++ b/src/api/admin/ui.ts
@@ -321,10 +321,10 @@ document.documentElement.dataset.theme = localStorage.getItem('aelios.admin.colo
           <p class="mt-1 text-[11px] leading-5 text-zinc-500">Dream、日记、周月卷、审核写记忆时只用这两个名字，不许写用户/助手。</p>
           <div class="mt-2 grid gap-2 md:grid-cols-[1fr_1fr_auto] md:items-end">
             <label class="text-xs text-zinc-400">用户叫什么
-              <input x-model="speakerUserName" class="mt-1 h-11 w-full rounded-xl border border-zinc-800 bg-zinc-900 px-3 text-sm text-zinc-100 outline-none focus:border-coral" placeholder="如 咲咲">
+              <input x-model="speakerUserName" class="mt-1 h-11 w-full rounded-xl border border-zinc-800 bg-zinc-900 px-3 text-sm text-zinc-100 outline-none focus:border-coral" placeholder="如 小南">
             </label>
             <label class="text-xs text-zinc-400">助手叫什么
-              <input x-model="speakerAssistantName" class="mt-1 h-11 w-full rounded-xl border border-zinc-800 bg-zinc-900 px-3 text-sm text-zinc-100 outline-none focus:border-coral" placeholder="如 旦九；留空用路径名">
+              <input x-model="speakerAssistantName" class="mt-1 h-11 w-full rounded-xl border border-zinc-800 bg-zinc-900 px-3 text-sm text-zinc-100 outline-none focus:border-coral" placeholder="如 小北；留空用路径名">
             </label>
             <button type="button" @click="saveSpeakers()" :disabled="speakerBusy" class="tap h-11 rounded-2xl bg-coral px-4 text-sm font-semibold text-zinc-950 transition duration-150 ease-in-out active:bg-coral/80 disabled:opacity-60">保存名字</button>
           </div>
@@ -1051,8 +1051,8 @@ document.documentElement.dataset.theme = localStorage.getItem('aelios.admin.colo
                 <button type="button" @click="gwIdentities.splice(i, 1)" class="tap shrink-0 rounded-xl border border-zinc-800 px-3 py-2 text-xs text-zinc-500 transition hover:border-coral hover:text-zinc-100">移除</button>
               </div>
               <div class="grid grid-cols-2 gap-2">
-                <input x-model="idn.userName" class="h-10 w-full rounded-xl border border-zinc-800 bg-zinc-900 px-3 text-sm text-zinc-100 outline-none focus:border-coral" placeholder="用户叫什么,如 咲咲">
-                <input x-model="idn.assistantName" class="h-10 w-full rounded-xl border border-zinc-800 bg-zinc-900 px-3 text-sm text-zinc-100 outline-none focus:border-coral" placeholder="助手叫什么,如 旦九">
+                <input x-model="idn.userName" class="h-10 w-full rounded-xl border border-zinc-800 bg-zinc-900 px-3 text-sm text-zinc-100 outline-none focus:border-coral" placeholder="用户叫什么,如 小南">
+                <input x-model="idn.assistantName" class="h-10 w-full rounded-xl border border-zinc-800 bg-zinc-900 px-3 text-sm text-zinc-100 outline-none focus:border-coral" placeholder="助手叫什么,如 小北">
               </div>
               <p class="text-[11px] text-zinc-500">Dream、日记、周月卷、审核写记忆只用这两个名字。助手名留空则用路径名。顶部选择助手后也能填。</p>
               <input x-model="idn.modelsText" class="h-10 w-full rounded-xl border border-zinc-800 bg-zinc-900 px-3 text-sm text-zinc-100 outline-none focus:border-coral" placeholder="主模型,逗号分隔,如 anthropic/claude-opus-5, *fable*">

--- a/tests/admin-selector.test.ts
+++ b/tests/admin-selector.test.ts
@@ -104,19 +104,19 @@ test('gateway editor round-trips speaker names for dream writing', async () => {
     }
     if (path === '/api/gateway/config') {
       return {
-        identities: [{ slug: 'danjiu', namespace: 'default', userName: '咲咲', assistantName: '旦九', keys: ['CHATBOX_API_KEY'], models: ['*'] }]
+        identities: [{ slug: 'danjiu', namespace: 'default', userName: '小南', assistantName: '小北', keys: ['CHATBOX_API_KEY'], models: ['*'] }]
       };
     }
     if (path === '/api/gateway/env') return { groups: [], secrets: [] };
     return { data: [] };
   };
   await app.gwLoad();
-  assert.equal(app.gwIdentities[0].userName, '咲咲');
-  assert.equal(app.gwIdentities[0].assistantName, '旦九');
+  assert.equal(app.gwIdentities[0].userName, '小南');
+  assert.equal(app.gwIdentities[0].assistantName, '小北');
   await app.gwSave();
-  assert.equal(saved[0].identities[0].userName, '咲咲');
-  assert.equal(saved[0].identities[0].assistantName, '旦九');
-  assert.match(ADMIN_HTML, /用户叫什么,如 咲咲/);
+  assert.equal(saved[0].identities[0].userName, '小南');
+  assert.equal(saved[0].identities[0].assistantName, '小北');
+  assert.match(ADMIN_HTML, /用户叫什么,如 小南/);
 });
 
 test('top identity picker saves speaker names without wiping the rest of gateway config', async () => {
@@ -141,12 +141,12 @@ test('top identity picker saves speaker names without wiping the rest of gateway
     return { data: [] };
   };
   app.selectedIdentity = 'danjiu';
-  app.speakerUserName = '咲咲';
-  app.speakerAssistantName = '旦九';
+  app.speakerUserName = '小南';
+  app.speakerAssistantName = '小北';
   await app.saveSpeakers();
   assert.equal(saved[0].upstream.address, 'https://keep.test/v1');
-  assert.equal(saved[0].identities[0].userName, '咲咲');
-  assert.equal(saved[0].identities[0].assistantName, '旦九');
+  assert.equal(saved[0].identities[0].userName, '小南');
+  assert.equal(saved[0].identities[0].assistantName, '小北');
   assert.equal(saved[0].identities[0].models[0], '*opus*');
   assert.equal(saved[0].identities[1].slug, 'ningjiao');
   assert.equal(saved[0].identities[1].userName, undefined);

--- a/tests/diary-grounding.test.ts
+++ b/tests/diary-grounding.test.ts
@@ -41,11 +41,11 @@ test("named speakers replace 用户/助手 in the diary prompt", () => {
       created_at: "2026-08-27T12:00:00.000Z"
     }],
     existingDraft: null,
-    speakers: { userName: "咲咲", assistantName: "旦九" }
+    speakers: { userName: "小南", assistantName: "小北" }
   });
-  assert.match(prompt, /用户是咲咲，助手是旦九/);
-  assert.match(prompt, /\[msg_1\].*\[咲咲\]/);
-  assert.match(prompt, /咲咲今天显得累/);
+  assert.match(prompt, /用户是小南，助手是小北/);
+  assert.match(prompt, /\[msg_1\].*\[小南\]/);
+  assert.match(prompt, /小南今天显得累/);
   assert.doesNotMatch(prompt, /用「我」指代助手自己/);
 });
 
@@ -68,15 +68,15 @@ test("diary JSON keeps title/summary and reads source_message_ids", () => {
 });
 
 test("named speakers replace 用户/助手 in weekly and monthly rollups", () => {
-  const speakers = { userName: "咲咲", assistantName: "旦九" };
+  const speakers = { userName: "小南", assistantName: "小北" };
   const weekly = buildWeeklyRollupPrompt({
     week: "2026-W36",
     startDate: "2026-08-31",
     endDate: "2026-09-06",
-    dailyLogs: [{ date: "2026-09-01", title: "累", summary: "咲咲有点累。" }],
+    dailyLogs: [{ date: "2026-09-01", title: "累", summary: "小南有点累。" }],
     speakers
   });
-  assert.match(weekly, /用户是咲咲，助手是旦九/);
+  assert.match(weekly, /用户是小南，助手是小北/);
   assert.doesNotMatch(weekly, /我=助手/);
   const monthly = buildMonthlyRollupPrompt({
     month: "2026-09",

--- a/tests/gateway.test.ts
+++ b/tests/gateway.test.ts
@@ -668,14 +668,14 @@ test("identity speaker names are optional, bounded, and used by the matching wri
   for (const bad of ["", " \n ", "n".repeat(33), "a\nb"]) {
     assert.throws(() => validateConfig({ ...config(), identities: [{ ...identity(), userName: bad }] }), /userName/);
   }
-  const named = { ...config(), identities: [{ ...identity(), userName: "咲咲", assistantName: "旦九" }] };
+  const named = { ...config(), identities: [{ ...identity(), userName: "小南", assistantName: "小北" }] };
   const saved = validateConfig(named);
-  assert.deepEqual(speakersForNamespace(saved, "partner-a"), { userName: "咲咲", assistantName: "旦九" });
+  assert.deepEqual(speakersForNamespace(saved, "partner-a"), { userName: "小南", assistantName: "小北" });
   assert.equal(speakersForNamespace(saved, "other"), null);
-  const slugFallback = validateConfig({ ...config(), identities: [{ ...identity(), userName: "咲咲" }] });
+  const slugFallback = validateConfig({ ...config(), identities: [{ ...identity(), userName: "小南" }] });
   assert.equal(speakersForNamespace(slugFallback, "partner-a")?.assistantName, "partner");
   assert.equal((await worker.fetch(request("/api/gateway/config", named, {}, "PUT"), env, ctx)).status, 200);
-  assert.deepEqual(JSON.parse((await run("/api/gateway/config")).text).identities[0].userName, "咲咲");
+  assert.deepEqual(JSON.parse((await run("/api/gateway/config")).text).identities[0].userName, "小南");
 });
 
 test("cross-space recall shares one budget, deduplicates and records provenance while writes stay in the new space", async () => {

--- a/tests/recall-quality.test.ts
+++ b/tests/recall-quality.test.ts
@@ -679,10 +679,10 @@ test("judge does not archive a still-valid fact and rejects string booleans", ()
   } as MemoryCandidateRow, [{
     id: "msg_1", conversation_id: "c", namespace: "ns", role: "user",
     content: "改成这样", source: "test", created_at: "2026-09-06T00:00:00.000Z"
-  }], { userName: "咲咲", assistantName: "旦九" });
-  assert.match(named, /用户是咲咲，助手是旦九/);
-  assert.match(named, /\[msg_1\].*\[咲咲\]/);
-  assert.match(named, /咲咲用新内容明确修正了旧事实/);
+  }], { userName: "小南", assistantName: "小北" });
+  assert.match(named, /用户是小南，助手是小北/);
+  assert.match(named, /\[msg_1\].*\[小南\]/);
+  assert.match(named, /小南用新内容明确修正了旧事实/);
 });
 
 test("FTS id hits keep SQL binds aligned and still find the rows", async () => {

--- a/tests/recall-selector.test.ts
+++ b/tests/recall-selector.test.ts
@@ -101,12 +101,12 @@ test("named speakers replace user/assistant labels in the dream extract prompt",
   const prompt = buildDreamExtractPrompt(
     [{ id: "msg_1", conversation_id: "c", namespace: "default", role: "user", content: "卖掉那台车", source: "test", created_at: "2026-09-08T00:00:00.000Z" }],
     [],
-    { userName: "咲咲", assistantName: "旦九" }
+    { userName: "小南", assistantName: "小北" }
   );
-  assert.match(prompt, /用户是咲咲，助手是旦九/);
+  assert.match(prompt, /用户是小南，助手是小北/);
   assert.match(prompt, /禁止出现 user、用户、assistant、助手/);
-  assert.match(prompt, /\[msg_1\].*\[咲咲\]/);
-  assert.match(prompt, /咲咲确定了九月按原计划卖掉那台车/);
+  assert.match(prompt, /\[msg_1\].*\[小南\]/);
+  assert.match(prompt, /小南确定了九月按原计划卖掉那台车/);
   assert.doesNotMatch(prompt, /关于用户的记忆，优先写成“你……”/);
   assert.doesNotMatch(prompt, /\[用户\]/);
   assert.doesNotMatch(prompt, /我\(助手\)/);
@@ -131,13 +131,13 @@ test("dream digest uses speaker names in transcript and writing rules", () => {
     messages: [{ id: "msg_1", conversation_id: "c", namespace: "default", role: "assistant", content: "好", source: "test", created_at: "2026-09-08T00:00:00.000Z" }],
     existingMemories: [],
     hasMore: false,
-    speakers: { userName: "咲咲", assistantName: "旦九" }
+    speakers: { userName: "小南", assistantName: "小北" }
   });
-  assert.match(named, /关于用户用「咲咲……」/);
+  assert.match(named, /关于用户用「小南……」/);
   assert.match(named, /禁止出现 user、用户、assistant、助手/);
-  assert.match(named, /\[msg_1\].*\[旦九\]/);
+  assert.match(named, /\[msg_1\].*\[小北\]/);
   assert.doesNotMatch(named, /我=助手/);
-  assert.equal(formatTranscript([{ id: "m", conversation_id: "c", namespace: "default", role: "user", content: "hi", source: null, created_at: "t" }], { userName: "咲咲", assistantName: "旦九" }), "[m][t][咲咲] hi");
+  assert.equal(formatTranscript([{ id: "m", conversation_id: "c", namespace: "default", role: "user", content: "hi", source: null, created_at: "t" }], { userName: "小南", assistantName: "小北" }), "[m][t][小南] hi");
 });
 
 test("default ranks exact contextual snippets once and keeps speaker and conditions", async () => {


### PR DESCRIPTION
## Why

Aelios is a public repo. The speaker-name fields shipped with personal names in the placeholders and tests.

## What

Admin placeholders and the speaker-name unit tests now use 小南 / 小北. Saved live names on danjiu are unchanged.

## Tests

- `npm run test:admin`
- `npm run test:diary`
- `npm run test:recall`
- `npm run test:gateway`