### PR TITLE
fix(gateway): learn any strippable tool field the upstream rejects

### DIFF
--- a/docs/memory-gateway.md
+++ b/docs/memory-gateway.md
@@ -184,8 +184,8 @@ Anthropic token counting。使用这些额外端点的客户端需要后续适�
 剥掉只损失一点延迟。一次 400 只报一个字段,客户端可能同时带多个,所以学习放在有界循环里,首轮最多每种字段多花一次往返。
 想不等这一次 400、每次先剥干净,在「设置 → 模型与线路」填 `UPSTREAM_STRIP_TOOL_FIELDS`(逗号分隔)。
 默认留空:那是按线路精确剥,只会影响真正拒绝它的上游,比一刀切剥所有 custom provider 更准。
-为兼容现有线路，网关把它转换成注入前最后一个可缓存块上的显式断点；已有断点保留，TTL 冲突或超过 4 个提前返回 400。
-没有顶层缓存设置就不主动添加断点。这个转换不等于保证所有上游支持同一套特性。
+这个设置是自由文本,但工具的身份字段(`name`/`description`/`input_schema`/`type`)会被拒绝并记一条日志 ——
+`validateRequest` 在剥离之前,否则会拆坏工具再出站。
 响应头 `x-aelios-identity/memory/provider/model` 用于诊断；实际模型与 Provider 优先读取 `cf-aig-model/provider`。
 `x-aelios-normalized` 表示删除的非规范字段数量，Worker 日志列出字段路径，不记录被删除的值。
 

--- a/docs/memory-gateway.md
+++ b/docs/memory-gateway.md
@@ -177,9 +177,13 @@ Anthropic token counting。使用这些额外端点的客户端需要后续适�
 顶层 `cache_control` 是 Anthropic 已支持的自动缓存字段，但部分 Vertex/代理线路仍会拒绝。
 为兼容现有线路，网关把它转换成注入前最后一个可缓存块上的显式断点；已有断点保留，TTL 冲突或超过 4 个提前返回 400。
 没有顶层缓存设置就不主动添加断点。这个转换不等于保证所有上游支持同一套特性。
-工具定义上的断点同理:实测 Vertex 线路拒绝工具级 cache_control(400 unrecognizedProperty),system/user 位置正常。
-网关按「学习」处理:某条线路 400 报这个签名,剥掉工具断点重试一次,并在本 isolate 记住,之后请求预先剥除;
-支持工具断点的线路永远学不到这条,不受影响。
+工具定义上的未知字段同理,网关按「学习」处理:某条线路 400 报 `unrecognizedProperty=<字段>`,
+剥掉该字段重试,并在本 isolate 按线路记住,之后请求预先剥除;支持该字段的线路永远学不到,不受影响。
+实测两种:Vertex 线路拒绝工具级 `cache_control`(system/user 位置正常);新版 Claude Code 会给每个工具
+带 `eager_input_streaming`,中转层和 Bedrock 之类不认,也走同一条学习路径 —— 该字段只调工具参数流式粒度,
+剥掉只损失一点延迟。一次 400 只报一个字段,客户端可能同时带多个,所以学习放在有界循环里,首轮最多每种字段多花一次往返。
+想不等这一次 400、每次先剥干净,在「设置 → 模型与线路」填 `UPSTREAM_STRIP_TOOL_FIELDS`(逗号分隔)。
+默认留空:那是按线路精确剥,只会影响真正拒绝它的上游,比一刀切剥所有 custom provider 更准。
 为兼容现有线路，网关把它转换成注入前最后一个可缓存块上的显式断点；已有断点保留，TTL 冲突或超过 4 个提前返回 400。
 没有顶层缓存设置就不主动添加断点。这个转换不等于保证所有上游支持同一套特性。
 响应头 `x-aelios-identity/memory/provider/model` 用于诊断；实际模型与 Provider 优先读取 `cf-aig-model/provider`。

--- a/src/gateway/handler.ts
+++ b/src/gateway/handler.ts
@@ -264,7 +264,7 @@ export async function handleGateway(request: Request, env: Env, ctx: ExecutionCo
   const payload = appendMemory(prepared.body, protocol, patch);
   if (protocol === "responses" && main) payload.store = false;
   try {
-    const upstream = await callGatewayUpstream(protocol, request, prepared, payload);
+    const upstream = await callGatewayUpstream(env, protocol, request, prepared, payload);
     const headers = new Headers(upstream.headers);
     headers.set("x-aelios-identity", identity.slug);
     headers.set("x-aelios-memory", memoryStatus);

--- a/src/gateway/protocol.ts
+++ b/src/gateway/protocol.ts
@@ -108,6 +108,8 @@ export function sanitizeCacheControl(body: Body, protocol: Protocol): void {
 // tunes tool-argument streaming granularity, so dropping it costs a little latency and
 // nothing else. Both are learned per upstream — see callGatewayUpstream.
 export const STRIPPABLE_TOOL_FIELDS: ReadonlySet<string> = new Set(["cache_control", "eager_input_streaming"]);
+/** A tool's identity, not a tuning knob: removing any of these ships a broken or useless tool. */
+export const PROTECTED_TOOL_FIELDS: ReadonlySet<string> = new Set(["name", "description", "input_schema", "type"]);
 /** Removing a field the tool never had reports false, so callers can tell a real retry from a no-op. */
 export function stripToolField(body: Body, field: string): boolean {
   let stripped = false;

--- a/src/gateway/protocol.ts
+++ b/src/gateway/protocol.ts
@@ -104,13 +104,22 @@ export function sanitizeCacheControl(body: Body, protocol: Protocol): void {
 }
 // Vertex-backed lines reject cache_control on tool definitions
 // (INVALID_ARGUMENT unrecognizedProperty=cache_control); system/user markers are fine.
-// The gateway learns this per upstream and strips only tool breakpoints there.
-export function stripToolCacheControl(body: Body): boolean {
+// Newer clients also stamp eager_input_streaming onto tool definitions; that field only
+// tunes tool-argument streaming granularity, so dropping it costs a little latency and
+// nothing else. Both are learned per upstream — see callGatewayUpstream.
+export const STRIPPABLE_TOOL_FIELDS: ReadonlySet<string> = new Set(["cache_control", "eager_input_streaming"]);
+/** Removing a field the tool never had reports false, so callers can tell a real retry from a no-op. */
+export function stripToolField(body: Body, field: string): boolean {
   let stripped = false;
   for (const tool of body.tools ?? []) {
-    if (object(tool) && tool.cache_control !== undefined) { delete tool.cache_control; stripped = true; }
+    if (object(tool) && tool[field] !== undefined) { delete tool[field]; stripped = true; }
   }
   return stripped;
+}
+/** Every `unrecognizedProperty=<name>` the upstream named, in its 400 detail. */
+export function rejectedFieldNames(detail: string): string[] {
+  const matches = detail.matchAll(/unrecognizedProperty=([A-Za-z_][A-Za-z0-9_]*)/g);
+  return [...new Set([...matches].map(match => match[1]))];
 }
 // Encrypted reasoning stays allowed; only server-owned history breaks request-only memory.
 export function hasServerState(body: Body, protocol: Protocol): boolean {

--- a/src/gateway/settings.ts
+++ b/src/gateway/settings.ts
@@ -28,6 +28,7 @@ export const SETTINGS: SettingSpec[] = [
   { group: "数据留存", name: "MESSAGES_RETENTION_DAYS", label: "原始对话保留天数", hint: "Dream 抽完记忆后，原文留几天" },
 
   { group: "模型与线路", name: "AI_GATEWAY_ID", label: "默认 AI Gateway ID", hint: "会写进上游 URL。自定义 Provider 和动态路由必须填对，不能只靠账户默认 Gateway" },
+  { group: "模型与线路", name: "UPSTREAM_STRIP_TOOL_FIELDS", label: "始终剥离的工具字段", hint: "逗号分隔，例如 eager_input_streaming,cache_control。留空则只在被上游拒绝一次后自动剥离（按线路记住，换 isolate 会重新学一次）；填上就每次都先剥干净，不会再看到那个 400" },
   { group: "模型与线路", name: "VISION_MODEL", label: "看图模型" },
   { group: "模型与线路", name: "CHAT_MODEL", label: "导盲犬入口的模型", hint: "只给 /v1/guide-dog 用，聊天走网关身份" },
   { group: "模型与线路", name: "PUBLIC_MODEL_NAME", label: "导盲犬对外显示的模型名" },

--- a/src/gateway/settings.ts
+++ b/src/gateway/settings.ts
@@ -28,7 +28,7 @@ export const SETTINGS: SettingSpec[] = [
   { group: "数据留存", name: "MESSAGES_RETENTION_DAYS", label: "原始对话保留天数", hint: "Dream 抽完记忆后，原文留几天" },
 
   { group: "模型与线路", name: "AI_GATEWAY_ID", label: "默认 AI Gateway ID", hint: "会写进上游 URL。自定义 Provider 和动态路由必须填对，不能只靠账户默认 Gateway" },
-  { group: "模型与线路", name: "UPSTREAM_STRIP_TOOL_FIELDS", label: "始终剥离的工具字段", hint: "逗号分隔，例如 eager_input_streaming,cache_control。留空则只在被上游拒绝一次后自动剥离（按线路记住，换 isolate 会重新学一次）；填上就每次都先剥干净，不会再看到那个 400" },
+  { group: "模型与线路", name: "UPSTREAM_STRIP_TOOL_FIELDS", label: "始终剥离的工具字段", hint: "逗号分隔，例如 eager_input_streaming,cache_control。填上就每次先剥，不再等上游那次 400。留空则按线路学习：只在被拒一次后自动剥离（换 isolate 会重学一次），接受该字段的上游不受影响。工具的身份字段 name/description/input_schema/type 会被拒绝" },
   { group: "模型与线路", name: "VISION_MODEL", label: "看图模型" },
   { group: "模型与线路", name: "CHAT_MODEL", label: "导盲犬入口的模型", hint: "只给 /v1/guide-dog 用，聊天走网关身份" },
   { group: "模型与线路", name: "PUBLIC_MODEL_NAME", label: "导盲犬对外显示的模型名" },

--- a/src/gateway/upstream.ts
+++ b/src/gateway/upstream.ts
@@ -1,6 +1,6 @@
 import type { Env } from "../types";
 import { isMainModel, PATHS, type GatewayConfig, type Identity, type Protocol } from "./config";
-import { applyThinkingPolicy, sanitizeCacheControl, stripToolCacheControl, type Body } from "./protocol";
+import { applyThinkingPolicy, rejectedFieldNames, sanitizeCacheControl, STRIPPABLE_TOOL_FIELDS, stripToolField, type Body } from "./protocol";
 import { normalizeRequest, validateRequest } from "./request";
 
 const ACCOUNT_RE = /^[a-f0-9]{32}$/i;
@@ -139,25 +139,48 @@ export function prepareGatewayRequest(env: Env, config: GatewayConfig, identity:
   validateRequest(out, protocol, headers);
   return { route, headers, body: out, removed: normalized.removed };
 }
-// Isolate-scope learned capability: Vertex-backed providers answer 400
-// "unrecognizedProperty=cache_control" to tool breakpoints. One learning 400 per
-// isolate per route; afterwards tool breakpoints are stripped before sending.
-export const toolCacheRejections = new Set<string>();
+// Isolate-scope learned capability: Vertex-backed and relay lines answer 400
+// "unrecognizedProperty=<field>" to tool-definition fields they do not know
+// (cache_control, eager_input_streaming). Once per isolate per route, the refused
+// fields are learned and stripped before every later send.
+export const rejectedToolFields = new Map<string, Set<string>>();
 
-export async function callGatewayUpstream(protocol: Protocol, original: Request,
+/** Operator escape hatch: strip these before the first send and never eat the 400. */
+function preStrippedToolFields(env: Env): string[] {
+  return (env.UPSTREAM_STRIP_TOOL_FIELDS || "").split(",")
+    .map(field => field.trim())
+    .filter(field => /^[A-Za-z_][A-Za-z0-9_]*$/.test(field))
+    .slice(0, 8);
+}
+
+export async function callGatewayUpstream(env: Env, protocol: Protocol, original: Request,
   prepared: PreparedRequest, body: Body): Promise<Response> {
   const { route, headers } = prepared;
   // Check the actual wire payload, including the gateway's own modifications.
   validateRequest(body, protocol, headers);
-  if (toolCacheRejections.has(route.url)) stripToolCacheControl(body);
+  const learned = rejectedToolFields.get(route.url);
+  if (learned) for (const field of learned) stripToolField(body, field);
+  for (const field of preStrippedToolFields(env)) stripToolField(body, field);
   const send = () => fetch(route.url, {
     method: "POST", headers, body: JSON.stringify(body), signal: original.signal, redirect: "manual"
   });
-  const first = await send();
-  if (first.status !== 400) return first;
-  const detail = await first.clone().text().catch(() => "");
-  if (!/unrecognizedProperty=cache_control/.test(detail) || !stripToolCacheControl(body)) return first;
-  toolCacheRejections.add(route.url);
-  console.log("gateway learned upstream rejects tool cache_control", { url: route.url });
-  return send();
+  let response = await send();
+  // A relay names one unknown field per 400, and a client can send several at once
+  // (eager_input_streaming on every tool, cache_control on the last one). Learn in a
+  // bounded loop so first contact costs at most one round per strippable field.
+  for (let round = 0; response.status === 400 && round < STRIPPABLE_TOOL_FIELDS.size; round++) {
+    const detail = await response.clone().text().catch(() => "");
+    // Only a field we actually removed justifies a retry; anything else is the caller's 400.
+    const refused: string[] = [];
+    for (const field of rejectedFieldNames(detail)) {
+      if (STRIPPABLE_TOOL_FIELDS.has(field) && stripToolField(body, field)) refused.push(field);
+    }
+    if (!refused.length) break;
+    const known = rejectedToolFields.get(route.url) ?? new Set<string>();
+    for (const field of refused) known.add(field);
+    rejectedToolFields.set(route.url, known);
+    console.log("gateway learned upstream rejects tool fields", { url: route.url, fields: refused });
+    response = await send();
+  }
+  return response;
 }

--- a/src/gateway/upstream.ts
+++ b/src/gateway/upstream.ts
@@ -1,6 +1,6 @@
 import type { Env } from "../types";
 import { isMainModel, PATHS, type GatewayConfig, type Identity, type Protocol } from "./config";
-import { applyThinkingPolicy, rejectedFieldNames, sanitizeCacheControl, STRIPPABLE_TOOL_FIELDS, stripToolField, type Body } from "./protocol";
+import { applyThinkingPolicy, PROTECTED_TOOL_FIELDS, rejectedFieldNames, sanitizeCacheControl, STRIPPABLE_TOOL_FIELDS, stripToolField, type Body } from "./protocol";
 import { normalizeRequest, validateRequest } from "./request";
 
 const ACCOUNT_RE = /^[a-f0-9]{32}$/i;
@@ -145,12 +145,25 @@ export function prepareGatewayRequest(env: Env, config: GatewayConfig, identity:
 // fields are learned and stripped before every later send.
 export const rejectedToolFields = new Map<string, Set<string>>();
 
+/** Setting values already reported, so a bad one warns once per isolate, not once per request. */
+const reportedStripSettings = new Set<string>();
+
 /** Operator escape hatch: strip these before the first send and never eat the 400. */
 function preStrippedToolFields(env: Env): string[] {
-  return (env.UPSTREAM_STRIP_TOOL_FIELDS || "").split(",")
-    .map(field => field.trim())
-    .filter(field => /^[A-Za-z_][A-Za-z0-9_]*$/.test(field))
-    .slice(0, 8);
+  const raw = env.UPSTREAM_STRIP_TOOL_FIELDS?.trim();
+  if (!raw) return [];
+  const named = raw.split(",").map(field => field.trim()).filter(field => /^[A-Za-z_][A-Za-z0-9_]*$/.test(field));
+  const usable = named.filter(field => !PROTECTED_TOOL_FIELDS.has(field));
+  // The setting is free text, and validateRequest already ran, so a typo naming a tool's
+  // identity would ship a broken tool. Refuse those, and say so rather than silently
+  // honouring a shorter list than the operator wrote.
+  if (usable.length !== named.length && !reportedStripSettings.has(raw)) {
+    reportedStripSettings.add(raw);
+    console.warn("UPSTREAM_STRIP_TOOL_FIELDS skipped tool identity fields", {
+      skipped: named.filter(field => PROTECTED_TOOL_FIELDS.has(field))
+    });
+  }
+  return usable;
 }
 
 export async function callGatewayUpstream(env: Env, protocol: Protocol, original: Request,

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,6 +13,8 @@ export interface Env {
   DEFAULT_UPSTREAM_MODEL?: string;
   ALLOW_MODEL_PASSTHROUGH?: string;
   AI_GATEWAY_BASE_URL?: string;
+  /** Comma-separated tool-definition fields to strip before every upstream send. */
+  UPSTREAM_STRIP_TOOL_FIELDS?: string;
   CHATBOX_API_KEY?: string;
   IM_API_KEY?: string;
   DEBUG_API_KEY?: string;

--- a/tests/gateway.test.ts
+++ b/tests/gateway.test.ts
@@ -6,7 +6,7 @@ import { timingSafeEqual } from "node:crypto";
 import worker from "../src/index";
 import { identityNamespace, identityReadNamespaces, invalidateSettingsCache, speakersForNamespace, validateConfig } from "../src/gateway/config";
 import { appendMemory, classifyTurn, canonical } from "../src/gateway/protocol";
-import { catalogUrl, resolveUpstream, routeFor, toolCacheRejections } from "../src/gateway/upstream";
+import { catalogUrl, resolveUpstream, routeFor, rejectedToolFields } from "../src/gateway/upstream";
 import { OutputCollector, observeResponse, persistExchange, prepareExchange, dispatchExchange } from "../src/gateway/record";
 
 import { lexicalOverlapScore, shapeRecallQuery } from "../src/memory/queryShape";
@@ -435,7 +435,7 @@ test("automatic caching lowers to the last cacheable block without rewriting sys
   assert.deepEqual(calls[2].query.messages[0].content[0].cache_control, cc);
 });
 test("upstream rejecting tool cache_control is learned: retry once stripped, then pre-strip", async () => {
-  toolCacheRejections.clear();
+  rejectedToolFields.clear();
   const vertexError = JSON.stringify({ errorCode: "INVALID_ARGUMENT",
     parameters: { unsafeParams: "{unrecognizedProperty=cache_control}" }, message: "Request contained an unrecognized field" });
   const baseFetch = globalThis.fetch;
@@ -460,7 +460,120 @@ test("upstream rejecting tool cache_control is learned: retry once stripped, the
     assert.equal(seen[2].tools[0].cache_control, undefined);
   } finally {
     globalThis.fetch = baseFetch;
-    toolCacheRejections.clear();
+    rejectedToolFields.clear();
+  }
+});
+test("upstream rejecting eager_input_streaming is learned the same way", async () => {
+  rejectedToolFields.clear();
+  const relayError = JSON.stringify({ errorCode: "INVALID_ARGUMENT", errorName: "LanguageModelService:InvalidRequest",
+    parameters: { unsafeParams: "{unrecognizedProperty=eager_input_streaming}" },
+    message: "Request contained an unrecognized field" });
+  const baseFetch = globalThis.fetch;
+  const seen: any[] = [];
+  let fail = true;
+  globalThis.fetch = async (url: any, init: any) => {
+    seen.push(JSON.parse(init?.body as string));
+    if (fail) { fail = false; return new Response(relayError, { status: 400 }); }
+    return baseFetch(url, init);
+  };
+  try {
+    const body = { model: "partner", max_tokens: 16,
+      tools: [{ name: "t", input_schema: { type: "object" }, eager_input_streaming: true }],
+      messages: [{ role: "user", content: "Hi" }] };
+    const { response } = await run("/v1/messages", body);
+    assert.equal(response.status, 200);
+    assert.equal(seen.length, 2);
+    assert.equal(seen[0].tools[0].eager_input_streaming, true);
+    assert.equal(seen[1].tools[0].eager_input_streaming, undefined);
+    await run("/v1/messages", body);
+    assert.equal(seen.length, 3);
+    assert.equal(seen[2].tools[0].eager_input_streaming, undefined);
+    // A field the gateway cannot strip must not trigger a blind retry.
+    assert.equal(seen.length, 3);
+  } finally {
+    globalThis.fetch = baseFetch;
+    rejectedToolFields.clear();
+  }
+});
+test("a relay refusing two tool fields learns both within one request", async () => {
+  rejectedToolFields.clear();
+  const baseFetch = globalThis.fetch;
+  const seen: any[] = [];
+  let round = 0;
+  globalThis.fetch = async (url: any, init: any) => {
+    const sent = JSON.parse(init?.body as string);
+    seen.push(sent);
+    round++;
+    // First pass rejects eager_input_streaming, second rejects cache_control, third succeeds.
+    if (round === 1) return new Response(JSON.stringify({ errorCode: "INVALID_ARGUMENT",
+      parameters: { unsafeParams: "{unrecognizedProperty=eager_input_streaming}" } }), { status: 400 });
+    if (round === 2) return new Response(JSON.stringify({ errorCode: "INVALID_ARGUMENT",
+      parameters: { unsafeParams: "{unrecognizedProperty=cache_control}" } }), { status: 400 });
+    return baseFetch(url, init);
+  };
+  try {
+    const body = { model: "partner", max_tokens: 16,
+      tools: [
+        { name: "a", input_schema: { type: "object" }, eager_input_streaming: true },
+        { name: "b", input_schema: { type: "object" }, eager_input_streaming: true,
+          cache_control: { type: "ephemeral" } }
+      ],
+      messages: [{ role: "user", content: "Hi" }] };
+    const { response } = await run("/v1/messages", body);
+    assert.equal(response.status, 200);
+    assert.equal(seen.length, 3);
+    assert.equal(seen[0].tools[0].eager_input_streaming, true);
+    assert.deepEqual(seen[1].tools[1].cache_control, { type: "ephemeral" });
+    assert.equal(seen[1].tools[0].eager_input_streaming, undefined);
+    assert.equal(seen[2].tools[0].eager_input_streaming, undefined);
+    assert.equal(seen[2].tools[1].cache_control, undefined);
+    // Both lessons stick for the next request.
+    await run("/v1/messages", body);
+    assert.equal(seen.length, 4);
+    assert.equal(seen[3].tools[0].eager_input_streaming, undefined);
+    assert.equal(seen[3].tools[1].cache_control, undefined);
+  } finally {
+    globalThis.fetch = baseFetch;
+    rejectedToolFields.clear();
+  }
+});
+test("an unrecognized field the gateway has no stripper for is returned, not retried", async () => {
+  rejectedToolFields.clear();
+  const junkError = JSON.stringify({ errorCode: "INVALID_ARGUMENT",
+    parameters: { unsafeParams: "{unrecognizedProperty=some_future_field}" }, message: "Request contained an unrecognized field" });
+  const baseFetch = globalThis.fetch;
+  let sends = 0;
+  globalThis.fetch = async () => { sends++; return new Response(junkError, { status: 400 }); };
+  try {
+    const { response } = await run("/v1/messages", { model: "partner", max_tokens: 16,
+      tools: [{ name: "t", input_schema: { type: "object" } }], messages: [{ role: "user", content: "Hi" }] });
+    assert.equal(response.status, 400);
+    assert.equal(sends, 1);
+    assert.equal(rejectedToolFields.size, 0);
+  } finally {
+    globalThis.fetch = baseFetch;
+    rejectedToolFields.clear();
+  }
+});
+test("UPSTREAM_STRIP_TOOL_FIELDS pre-strips before the first send, no learning 400", async () => {
+  rejectedToolFields.clear();
+  env.UPSTREAM_STRIP_TOOL_FIELDS = "eager_input_streaming, cache_control";
+  const baseFetch = globalThis.fetch;
+  const seen: any[] = [];
+  globalThis.fetch = async (url: any, init: any) => { seen.push(JSON.parse(init?.body as string)); return baseFetch(url, init); };
+  try {
+    const { response } = await run("/v1/messages", { model: "partner", max_tokens: 16,
+      tools: [{ name: "t", input_schema: { type: "object" }, eager_input_streaming: true,
+        cache_control: { type: "ephemeral" } }],
+      messages: [{ role: "user", content: "Hi" }] });
+    assert.equal(response.status, 200);
+    assert.equal(seen.length, 1);
+    assert.equal(seen[0].tools[0].eager_input_streaming, undefined);
+    assert.equal(seen[0].tools[0].cache_control, undefined);
+  } finally {
+    globalThis.fetch = baseFetch;
+    delete env.UPSTREAM_STRIP_TOOL_FIELDS;
+    rejectedToolFields.clear();
   }
 });
 test("Queue failure falls back to D1; successful duplicate cannot overwrite complete record", async () => {

--- a/tests/gateway.test.ts
+++ b/tests/gateway.test.ts
@@ -488,8 +488,6 @@ test("upstream rejecting eager_input_streaming is learned the same way", async (
     await run("/v1/messages", body);
     assert.equal(seen.length, 3);
     assert.equal(seen[2].tools[0].eager_input_streaming, undefined);
-    // A field the gateway cannot strip must not trigger a blind retry.
-    assert.equal(seen.length, 3);
   } finally {
     globalThis.fetch = baseFetch;
     rejectedToolFields.clear();
@@ -537,21 +535,47 @@ test("a relay refusing two tool fields learns both within one request", async ()
     rejectedToolFields.clear();
   }
 });
-test("an unrecognized field the gateway has no stripper for is returned, not retried", async () => {
+test("an unrecognized field that is not strippable is returned, not retried", async () => {
   rejectedToolFields.clear();
+  // `strict` is contract-legal and survives normalization, so it really is on the wire.
+  // It is deliberately absent from STRIPPABLE_TOOL_FIELDS: dropping the whitelist check
+  // would strip it and retry, turning this test red.
   const junkError = JSON.stringify({ errorCode: "INVALID_ARGUMENT",
-    parameters: { unsafeParams: "{unrecognizedProperty=some_future_field}" }, message: "Request contained an unrecognized field" });
+    parameters: { unsafeParams: "{unrecognizedProperty=strict}" }, message: "Request contained an unrecognized field" });
   const baseFetch = globalThis.fetch;
   let sends = 0;
   globalThis.fetch = async () => { sends++; return new Response(junkError, { status: 400 }); };
   try {
     const { response } = await run("/v1/messages", { model: "partner", max_tokens: 16,
-      tools: [{ name: "t", input_schema: { type: "object" } }], messages: [{ role: "user", content: "Hi" }] });
+      tools: [{ name: "t", input_schema: { type: "object" }, strict: true }],
+      messages: [{ role: "user", content: "Hi" }] });
     assert.equal(response.status, 400);
     assert.equal(sends, 1);
     assert.equal(rejectedToolFields.size, 0);
   } finally {
     globalThis.fetch = baseFetch;
+    rejectedToolFields.clear();
+  }
+});
+test("UPSTREAM_STRIP_TOOL_FIELDS refuses to strip a tool's identity", async () => {
+  rejectedToolFields.clear();
+  // A typo here would otherwise ship a tool with no name or schema past validation.
+  env.UPSTREAM_STRIP_TOOL_FIELDS = "name, input_schema, eager_input_streaming";
+  const baseFetch = globalThis.fetch;
+  const seen: any[] = [];
+  globalThis.fetch = async (url: any, init: any) => { seen.push(JSON.parse(init?.body as string)); return baseFetch(url, init); };
+  try {
+    const { response } = await run("/v1/messages", { model: "partner", max_tokens: 16,
+      tools: [{ name: "t", input_schema: { type: "object" }, eager_input_streaming: true }],
+      messages: [{ role: "user", content: "Hi" }] });
+    assert.equal(response.status, 200);
+    assert.equal(seen.length, 1);
+    assert.equal(seen[0].tools[0].name, "t");
+    assert.deepEqual(seen[0].tools[0].input_schema, { type: "object" });
+    assert.equal(seen[0].tools[0].eager_input_streaming, undefined);
+  } finally {
+    globalThis.fetch = baseFetch;
+    delete env.UPSTREAM_STRIP_TOOL_FIELDS;
     rejectedToolFields.clear();
   }
 });


### PR DESCRIPTION
## 问题

新版 Claude Code（2.1.69+）会给每个工具定义加 `eager_input_streaming`。中转层、Bedrock、Vertex 不认这个字段，整个请求被打回：

```json
{ "errorCode": "INVALID_ARGUMENT",
  "errorName": "LanguageModelService:InvalidRequest",
  "parameters": { "unsafeParams": "{unrecognizedProperty=eager_input_streaming}" } }
```

仓库里已经有针对 `cache_control` 的「学习式」剥离（`toolCacheRejections`），但它按名字硬匹配那一个字段，换个字段名就失效。

## 改动

**`protocol.ts`** — 泛化
- `STRIPPABLE_TOOL_FIELDS` 白名单：`cache_control`、`eager_input_streaming`
- `stripToolField(body, field)` 剥一个字段并返回是否真的剥到了
- `rejectedFieldNames(detail)` 抓出上游 400 里所有 `unrecognizedProperty=<名字>`

**`upstream.ts`** — 学习
- `rejectedToolFields: Map<routeUrl, Set<field>>` 按线路记住被拒字段
- 学习改成**有界循环**：一次 400 只报一个字段，而客户端可能同时带多个（`eager_input_streaming` 在每个工具上、`cache_control` 在最后一个），所以首轮最多每种字段多花一次往返
- 只剥白名单内的字段。报一个没有剥离器的字段时原样返回 400，**不盲目重试**
- `callGatewayUpstream` 加 `env` 首参（沿用 repo 里 env 排第一的约定）

**`settings.ts` / `types.ts`** — 新增 `UPSTREAM_STRIP_TOOL_FIELDS`

逗号分隔。填上就每次发送前先剥干净，不用等那一次 400。**默认留空**：默认是按线路精确剥离，只会影响真正拒绝该字段的上游，接受该字段的线路永远学不到；比一刀切剥所有 custom provider 更准。

## 验证

- `tsc`（src + tests）通过
- `biome lint` 仍是 17 warning / 0 error，与仓库基线一致
- 154 个测试全过，新增 5 个：单字段学习、双字段级联、不可剥字段不重试、预剥、以及 `cache_control` 原有用例
- 用真实 payload 重放：7 个工具都带 `eager_input_streaming`，3 个 cache 断点（system / tools[6] / messages[0]），走完整 `normalize` → `validate` → 学习剥离后重试体干净

与本次改动无关的既有失败：`scripts/verify-dedup-gate.mjs` 和 `verify-week-blocks.mjs` 报 `Invalid date label: 09/10/2026`。本地 Node 是 small-icu，`Intl.DateTimeFormat('en-CA')` 被解析成 `en` 给了美式格式；Workers 全量 ICU 给 `YYYY-MM-DD`。基线 stash 后同样失败。
